### PR TITLE
fix: windows config under APPDATA, drive-letter file urls, platform-gated path tests

### DIFF
--- a/crates/plannotator-tui/src/config.rs
+++ b/crates/plannotator-tui/src/config.rs
@@ -109,6 +109,10 @@ pub(crate) fn config_path(env: impl Fn(&str) -> Option<String>, home: &Path) -> 
     if let Some(explicit) = env("PLANNOTATOR_TUI_CONFIG").filter(|s| !s.is_empty()) {
         return PathBuf::from(explicit);
     }
+    #[cfg(windows)]
+    if let Some(appdata) = env("APPDATA").map(PathBuf::from).filter(|p| p.is_absolute()) {
+        return appdata.join("plannotator-tui").join("config.toml");
+    }
     let xdg = env("XDG_CONFIG_HOME").map(PathBuf::from).filter(|p| p.is_absolute());
     xdg.unwrap_or_else(|| home.join(".config")).join("plannotator-tui").join("config.toml")
 }
@@ -170,6 +174,17 @@ mod tests {
         assert_eq!(config.herdr.popup_width, "90%");
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn config_lives_under_appdata_on_windows() {
+        let lookup = |k: &str| (k == "APPDATA").then(|| r"C:\Users\u\AppData\Roaming".to_owned());
+        assert_eq!(
+            config_path(lookup, Path::new(r"C:\Users\u")),
+            PathBuf::from(r"C:\Users\u\AppData\Roaming\plannotator-tui\config.toml")
+        );
+    }
+
+    #[cfg(unix)]
     #[test]
     fn config_path_precedence() {
         let home = Path::new("/home/u");

--- a/crates/plannotator-tui/src/herdr/launch.rs
+++ b/crates/plannotator-tui/src/herdr/launch.rs
@@ -45,7 +45,16 @@ fn file_url_path(url: &str) -> Option<PathBuf> {
         Some(slash) if matches!(&rest[..slash], "" | "localhost") => &rest[slash..],
         _ => return None,
     };
-    Some(PathBuf::from(percent_decode(path)))
+    let decoded = percent_decode(path);
+    // Windows: `file:///C:/x` carries a leading slash before the drive letter.
+    #[cfg(windows)]
+    let decoded = match decoded.as_bytes() {
+        [b'/', drive, b':', ..] if drive.is_ascii_alphabetic() => {
+            decoded.get(1..).unwrap_or_default().to_owned()
+        }
+        _ => decoded,
+    };
+    Some(PathBuf::from(decoded))
 }
 
 fn percent_decode(s: &str) -> String {

--- a/crates/plannotator-tui/src/herdr/launch/tests.rs
+++ b/crates/plannotator-tui/src/herdr/launch/tests.rs
@@ -80,7 +80,11 @@ fn agent_skill_delivers_to_and_splits_beside_the_calling_pane() {
 #[test]
 fn ctrl_click_opens_the_linked_file() {
     let root = temp_folder("click");
-    let url = format!("file://{}/docs/plan.md", root.display());
+    // `file:///abs/path` on Unix; `file:///C:/abs/path` on Windows.
+    let url = format!(
+        "file:///{}/docs/plan.md",
+        root.display().to_string().replace('\\', "/").trim_start_matches('/')
+    );
     let context = HerdrContext {
         focused_pane_id: Some("w1:p1".into()),
         focused_pane_agent: Some("claude".into()),

--- a/crates/plannotator-tui/src/workspace_paths.rs
+++ b/crates/plannotator-tui/src/workspace_paths.rs
@@ -58,6 +58,6 @@ mod tests {
         #[cfg(unix)]
         assert_eq!(absolute(Path::new("/a/b/../c/./d.md")), PathBuf::from("/a/c/d.md"));
         #[cfg(windows)]
-        assert_eq!(absolute(Path::new(r"C:\\a\\b\\..\\c\\.\\d.md")), PathBuf::from(r"C:\\a\\c\\d.md"));
+        assert_eq!(absolute(Path::new(r"C:\a\b\..\c\.\d.md")), PathBuf::from(r"C:\a\c\d.md"));
     }
 }

--- a/crates/plannotator-tui/src/workspace_paths.rs
+++ b/crates/plannotator-tui/src/workspace_paths.rs
@@ -55,6 +55,9 @@ mod tests {
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
         assert_eq!(absolute(Path::new("docs/plan.md")), cwd.join("docs/plan.md"));
         assert_eq!(absolute(Path::new("./docs/../docs/plan.md")), cwd.join("docs/plan.md"));
+        #[cfg(unix)]
         assert_eq!(absolute(Path::new("/a/b/../c/./d.md")), PathBuf::from("/a/c/d.md"));
+        #[cfg(windows)]
+        assert_eq!(absolute(Path::new(r"C:\\a\\b\\..\\c\\.\\d.md")), PathBuf::from(r"C:\\a\\c\\d.md"));
     }
 }


### PR DESCRIPTION
Windows: config under %APPDATA%, file:///C:/… URLs, and the three path tests gated per platform. Found by the first post-merge matrix run.