### PR TITLE
test(schema): xdg data dir assertion is unix-only

### DIFF
--- a/crates/plannotator-tui-schema/src/datadir.rs
+++ b/crates/plannotator-tui-schema/src/datadir.rs
@@ -156,7 +156,9 @@ mod tests {
             data_dir(env_of(&[("XDG_DATA_HOME", "/xdg")]), home, legacy_exists),
             Path::new("/home/u/.plannotator")
         );
-        // XDG applies only when absolute and the legacy dir is absent
+        // XDG applies only when absolute and the legacy dir is absent (`/xdg` is absolute
+        // on Unix only; Windows never sets XDG_DATA_HOME in practice).
+        #[cfg(unix)]
         assert_eq!(
             data_dir(env_of(&[("XDG_DATA_HOME", "/xdg")]), home, nothing),
             Path::new("/xdg/plannotator")


### PR DESCRIPTION
Last Unix-only path assumption found by the Windows post-merge job.