### PR TITLE
build: strip shipped binaries; keep a profiling profile with debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,5 +48,11 @@ cast_possible_wrap = "allow"
 cast_precision_loss = "allow"
 
 [profile.release]
-debug = 1
 lto = "thin"
+# Shipped binaries carry no debug info; profile locally with `--profile profiling`.
+strip = true
+
+[profile.profiling]
+inherits = "release"
+debug = 1
+strip = false


### PR DESCRIPTION
Linux release assets were 16 MB because the release profile kept debug info. Strip them; profile locally with --profile profiling.