### PR TITLE
feat(app): folder mode sends every annotated file; header is just the send button

### DIFF
--- a/crates/plannotator-tui/src/app/draw.rs
+++ b/crates/plannotator-tui/src/app/draw.rs
@@ -351,6 +351,7 @@ impl App {
         }
         let orphans = self.open.store.orphans();
         let mut parts = vec![
+            self.open.source.name.clone(),
             format!("{} blocks", self.open.doc.blocks.len()),
             format!(
                 "{} annotations{}",

--- a/crates/plannotator-tui/src/app/draw.rs
+++ b/crates/plannotator-tui/src/app/draw.rs
@@ -352,7 +352,6 @@ impl App {
         let orphans = self.open.store.orphans();
         let mut parts = vec![
             self.open.source.name.clone(),
-            format!("{} blocks", self.open.doc.blocks.len()),
             format!(
                 "{} annotations{}",
                 self.open.store.len(),
@@ -365,7 +364,6 @@ impl App {
                 }
                 None => format!("block {}/{}", self.selected + 1, self.open.doc.blocks.len()),
             },
-            format!("frame {:.2}ms (max {:.1})", self.frame_ms, self.frame_max_ms),
         ];
         if let Some(status) = &self.status {
             parts.push(status.clone());
@@ -373,14 +371,11 @@ impl App {
         if frame.area().width < RAIL_MIN_TOTAL_WIDTH {
             parts.push("rail hidden: widen to ≥80 cols".into());
         }
-        let target = self.delivery.describe();
         let help = match self.focus {
-            _ if self.pending.is_some() => "a looks good · c comment · d delete · esc clear ".to_owned(),
-            Focus::Tree => format!("j/k move · enter open · E send folder → {target} · t hide · q quit "),
-            Focus::Rail => "j/k move · e edit · x remove · tab focus · q quit ".to_owned(),
-            Focus::Document => {
-                format!("drag or v select · c comment · E send → {target} · tab focus · q quit ")
-            }
+            _ if self.pending.is_some() => "a looks good · c comment · d delete · esc clear ",
+            Focus::Tree => "j/k · enter open · E send · t hide · q quit ",
+            Focus::Rail => "j/k · e edit · x remove · tab · q quit ",
+            Focus::Document => "drag or v select · c comment · E send · tab · q quit ",
         };
         let [left_area, right_area] =
             Layout::horizontal([Constraint::Min(10), Constraint::Length(help.width() as u16)]).areas(area);

--- a/crates/plannotator-tui/src/app/header.rs
+++ b/crates/plannotator-tui/src/app/header.rs
@@ -1,20 +1,15 @@
-//! The header row: the open file's name on the left, the Send button and the brand on the
-//! right. The button is the only clickable thing here, so its rect is recorded for
-//! hit-testing.
+//! The header row: the Send button, right-aligned, and nothing else. The pane label
+//! (Herdr's) names the app; the footer names the file. The button is clickable, so its rect
+//! is recorded for hit-testing.
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style, Stylize};
-use ratatui::text::{Line, Span};
-use ratatui::widgets::Paragraph;
+use ratatui::style::{Color, Modifier, Style, Stylize as _};
+use ratatui::text::Span;
 use unicode_width::UnicodeWidthStr;
 
 use super::App;
 use super::send::SendState;
-
-const BRAND: &str = "plannotator-tui ";
-/// The name keeps at least this much room; below it the button is dropped instead.
-const MIN_NAME_WIDTH: u16 = 8;
 
 const SEND_BG: Color = Color::Indexed(30);
 const IDLE_BG: Color = Color::Indexed(238);
@@ -24,30 +19,9 @@ const BLOCKED_BG: Color = Color::Indexed(58);
 impl App {
     pub(super) fn draw_header(&mut self, frame: &mut Frame, area: Rect) {
         let button = format!(" {} ", self.send_label());
-        let button_width = button.width() as u16;
-        let brand_width = BRAND.width() as u16;
-        // The name is drawn with one leading space.
-        let name_width = self.open.source.name.width() as u16 + 1;
-
-        // Space runs out from the right: the brand goes first, then the button. The name is
-        // truncated to whatever is left of the button, never painted over.
-        let (brand, button_x) = if area.width >= name_width + button_width + brand_width {
-            (true, Some(area.right().saturating_sub(brand_width + button_width)))
-        } else if area.width >= MIN_NAME_WIDTH + button_width {
-            (false, Some(area.right().saturating_sub(button_width)))
-        } else {
-            (false, None)
-        };
-
-        let room = button_x.map_or(area.width, |x| x.saturating_sub(area.x));
-        let name: String = self.open.source.name.chars().take(usize::from(room.saturating_sub(1))).collect();
-        let title = Line::from(vec![Span::raw(" "), Span::styled(name, Style::new().bold())]);
-        frame.render_widget(Paragraph::new(title), area);
-        if brand {
-            frame.render_widget(Paragraph::new(Line::from(Span::raw(BRAND).dim()).right_aligned()), area);
-        }
-
-        self.geometry.send_button = button_x.map(|x| Rect { x, y: area.y, width: button_width, height: 1 });
+        let width = button.width() as u16;
+        self.geometry.send_button =
+            (area.width >= width).then(|| Rect { x: area.right() - width, y: area.y, width, height: 1 });
         if let Some(rect) = self.geometry.send_button {
             let span = Span::styled(button, self.button_style());
             frame.buffer_mut().set_span(rect.x, rect.y, &span, rect.width);

--- a/crates/plannotator-tui/src/app/header.rs
+++ b/crates/plannotator-tui/src/app/header.rs
@@ -4,7 +4,7 @@
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style, Stylize as _};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
 use unicode_width::UnicodeWidthStr;
 

--- a/crates/plannotator-tui/src/app/mod.rs
+++ b/crates/plannotator-tui/src/app/mod.rs
@@ -331,6 +331,54 @@ impl App {
         Ok(if out.is_empty() { "No changes detected.".to_owned() } else { out })
     }
 
+    /// Paths of every annotated file in the folder, the open one included.
+    fn annotated_files(&self) -> Vec<PathBuf> {
+        self.tree.as_ref().map_or_else(Vec::new, |tree| {
+            tree.rows.iter().filter(|r| !r.is_dir && r.annotations > 0).map(|r| r.path.clone()).collect()
+        })
+    }
+
+    fn is_open(&self, path: &Path) -> bool {
+        matches!(&self.open.source.provenance, Provenance::File { path: p } if p == path)
+    }
+
+    /// Remember the send on every file it covered: the open one in memory, the rest on disk.
+    fn record_delivery(&mut self, target: &str) -> Result<()> {
+        if self.tree.is_none() {
+            return self.open.store.record_delivery(target);
+        }
+        let width = self.open.layout.width;
+        for path in self.annotated_files() {
+            if self.is_open(&path) {
+                self.open.store.record_delivery(target)?;
+            } else {
+                let mut open = Open::new(read_file(&path)?, width, &self.data_dir, &self.project)?;
+                open.store.record_delivery(target)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// True when every annotated file in the folder has been sent since it last changed.
+    fn folder_all_delivered(&self) -> Result<bool> {
+        let files = self.annotated_files();
+        if files.is_empty() {
+            return Ok(false);
+        }
+        let width = self.open.layout.width;
+        for path in files {
+            let delivered = if self.is_open(&path) {
+                self.open.store.all_delivered()
+            } else {
+                Open::new(read_file(&path)?, width, &self.data_dir, &self.project)?.store.all_delivered()
+            };
+            if !delivered {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
     fn clear_selection(&mut self) {
         self.selection = None;
         self.pending = None;

--- a/crates/plannotator-tui/src/app/send.rs
+++ b/crates/plannotator-tui/src/app/send.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 
-use super::{App, Focus, Mode};
+use super::{App, Mode};
 use crate::delivery::{Clipboard, Delivery as _, DeliveryError};
 
 /// What the Send button says. Re-derived from the store on load and file switch.
@@ -17,14 +17,14 @@ pub(super) enum SendState {
 }
 
 impl App {
-    /// Send feedback: the open file's, or every annotated file's when the tree has focus.
+    /// Send feedback: every annotated file's in folder mode, else the open file's.
     pub(super) fn send_feedback(&mut self) -> Result<()> {
-        let text = if self.focus == Focus::Tree { self.folder_feedback()? } else { self.feedback() };
+        let text = if self.tree.is_some() { self.folder_feedback()? } else { self.feedback() };
         let count = self.send_count();
         let target = self.delivery.describe();
         match self.delivery.deliver(&text) {
             Ok(()) => {
-                self.open.store.record_delivery(&target)?;
+                self.record_delivery(&target)?;
                 self.send_state = SendState::Sent;
                 self.status = Some(format!("sent {count} annotation(s) → {target}"));
             }
@@ -51,12 +51,11 @@ impl App {
         }
     }
 
-    /// Annotations the next send covers: the open file's, or the folder's when the tree
-    /// has focus.
+    /// Annotations the next send covers: the whole folder's, or the open file's.
     pub(super) fn send_count(&self) -> usize {
-        match (&self.tree, self.focus) {
-            (Some(tree), Focus::Tree) => tree.rows.iter().filter(|r| !r.is_dir).map(|r| r.annotations).sum(),
-            _ => self.open.store.placed().len(),
+        match &self.tree {
+            Some(tree) => tree.rows.iter().filter(|r| !r.is_dir).map(|r| r.annotations).sum(),
+            None => self.open.store.placed().len(),
         }
     }
 
@@ -80,7 +79,7 @@ impl App {
 
     /// True when an agent is waiting on feedback that has not been sent since it changed.
     pub(super) fn has_unsent(&self) -> bool {
-        self.delivery.is_agent() && self.open.store.len() > 0 && self.send_state != SendState::Sent
+        self.delivery.is_agent() && self.send_count() > 0 && self.send_state != SendState::Sent
     }
 
     /// Quit, unless an agent is still waiting on feedback: then ask in the footer first.
@@ -94,7 +93,11 @@ impl App {
 
     /// Recompute the send state from the record (on load and file switch).
     pub(super) fn derive_send_state(&mut self) {
-        self.send_state = if self.open.store.all_delivered() { SendState::Sent } else { SendState::Ready };
+        let delivered = match &self.tree {
+            Some(_) => self.folder_all_delivered().unwrap_or(false),
+            None => self.open.store.all_delivered(),
+        };
+        self.send_state = if delivered { SendState::Sent } else { SendState::Ready };
     }
 
     /// Any annotation change makes the record unsent again.

--- a/crates/plannotator-tui/src/app/tests.rs
+++ b/crates/plannotator-tui/src/app/tests.rs
@@ -54,10 +54,9 @@ fn the_header_draws_the_send_button_and_records_where_it_is() {
     let rows = draw(&mut app);
     let header = row(&rows, 0);
     assert!(header.contains("Send 1 to claude in w1:p1 ▸"), "header was {header:?}");
-    assert!(header.contains("plannotator-tui"), "the brand still fits: {header:?}");
     let rect = app.geometry.send_button.expect("button rect recorded");
     assert_eq!(rect.y, 0);
-    assert!(rect.right() <= 80);
+    assert_eq!(rect.right(), 80, "the button sits on the right edge");
 }
 
 #[test]

--- a/crates/plannotator-tui/tests/folder_export.rs
+++ b/crates/plannotator-tui/tests/folder_export.rs
@@ -1,0 +1,40 @@
+//! Folder mode covers every annotated file, through the real binary and a private data dir.
+
+#![allow(clippy::expect_used, reason = "tests assert by panicking")]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_plannotator-tui"))
+}
+
+#[test]
+fn folder_export_includes_every_annotated_file() {
+    let root = std::env::temp_dir().join(format!("plannotator-tui-folder-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let docs = root.join("docs");
+    std::fs::create_dir_all(&docs).expect("dirs");
+    std::fs::write(docs.join("a.md"), "# A\n\nalpha text\n").expect("a");
+    std::fs::write(docs.join("b.md"), "# B\n\nbeta text\n").expect("b");
+    let data: PathBuf = root.join("data");
+
+    for (file, quote) in [("a.md", "alpha"), ("b.md", "beta")] {
+        let status = bin()
+            .env("PLANNOTATOR_DATA_DIR", &data)
+            .args(["--annotate", &docs.join(file).display().to_string(), quote, "note", "comment"])
+            .status()
+            .expect("annotate runs");
+        assert!(status.success(), "annotating {file}");
+    }
+    let out = bin()
+        .env("PLANNOTATOR_DATA_DIR", &data)
+        .args(["--export", &docs.display().to_string()])
+        .output()
+        .expect("export runs");
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(text.contains("## File: a.md"), "{text}");
+    assert!(text.contains("## File: b.md"), "{text}");
+    assert!(text.contains("\"alpha\"") && text.contains("\"beta\""), "{text}");
+    std::fs::remove_dir_all(&root).expect("cleanup");
+}


### PR DESCRIPTION
From live testing: no file name or brand in the header (button right-aligned), footer names the file, folder mode sends and tracks every annotated file.