### PR TITLE
feat(export): annotations, not plan feedback

### DIFF
--- a/crates/plannotator-tui/src/app/mod.rs
+++ b/crates/plannotator-tui/src/app/mod.rs
@@ -314,10 +314,10 @@ impl App {
 
     /// The feedback document for every placed annotation of the open file.
     pub(crate) fn feedback(&self) -> String {
-        Self::feedback_for(&self.open)
+        Self::feedback_for(&self.open, &self.open.source.name)
     }
 
-    fn feedback_for(open: &Open) -> String {
+    fn feedback_for(open: &Open, name: &str) -> String {
         let source = &open.doc.source;
         let entries: Vec<export::Entry<'_>> = open
             .store
@@ -329,10 +329,10 @@ impl App {
                 range: p.range.clone(),
             })
             .collect();
-        export::feedback(source, "plan", &entries)
+        export::feedback(source, name, &entries)
     }
 
-    /// Feedback for every annotated file in the folder, one `## File:` section each.
+    /// Feedback for every annotated file in the folder, one `# Annotations on <path>` block each.
     pub(crate) fn folder_feedback(&self) -> Result<String> {
         let Some(tree) = &self.tree else { return Ok(self.feedback()) };
         let width = self.open.layout.width;
@@ -340,9 +340,9 @@ impl App {
         for row in tree.rows.iter().filter(|r| !r.is_dir && r.annotations > 0) {
             let open = Open::new(read_file(&row.path)?, width, &self.data_dir, &self.project)?;
             let relative = row.path.strip_prefix(tree.root()).unwrap_or(&row.path);
-            let _ = writeln!(out, "## File: {}\n\n{}", relative.display(), Self::feedback_for(&open));
+            let _ = writeln!(out, "{}", Self::feedback_for(&open, &relative.display().to_string()));
         }
-        Ok(if out.is_empty() { "No changes detected.".to_owned() } else { out })
+        Ok(if out.is_empty() { "No annotations.".to_owned() } else { out })
     }
 
     /// Paths of every annotated file in the folder, the open one included.

--- a/crates/plannotator-tui/src/export.rs
+++ b/crates/plannotator-tui/src/export.rs
@@ -1,8 +1,8 @@
-//! Feedback export: annotations as the numbered Markdown a coding agent expects.
+//! Feedback export: annotations as numbered Markdown a coding agent reads without a schema.
 //!
-//! The shape follows Plannotator's `exportAnnotations` so an agent that has read one kind
-//! of feedback reads the other the same way: a title, a count line, then one `## N.` entry
-//! per annotation in document order, each quoting the text and carrying the note.
+//! `# Annotations on <name>`, then one `## Annotation N (line X)` per annotation in document
+//! order: what kind of note it is, the quoted text, and the body as a blockquote. Deleted
+//! text is fenced so quoted markdown cannot escape.
 
 use std::fmt::Write as _;
 use std::ops::Range;
@@ -17,43 +17,33 @@ pub(crate) struct Entry<'a> {
     pub(crate) lines: (usize, usize),
 }
 
-pub(crate) fn feedback(source: &str, subject: &str, entries: &[Entry<'_>]) -> String {
+pub(crate) fn feedback(source: &str, name: &str, entries: &[Entry<'_>]) -> String {
     if entries.is_empty() {
-        return "No changes detected.".to_owned();
+        return "No annotations.".to_owned();
     }
-    let mut out = String::from("# Plan Feedback\n\n");
-    let n = entries.len();
-    let _ = write!(
-        out,
-        "I've reviewed this {subject} and have {n} piece{} of feedback:\n\n",
-        if n > 1 { "s" } else { "" }
-    );
+    let mut out = format!("# Annotations on {name}\n\n");
     for (i, entry) in entries.iter().enumerate() {
         let quoted = source.get(entry.range.clone()).unwrap_or("");
         let line_label = match entry.lines {
             (a, b) if a == b => format!("line {a}"),
             (a, b) => format!("lines {a}\u{2013}{b}"),
         };
-        let _ = write!(out, "## {}. ({line_label}) ", i + 1);
+        let _ = writeln!(out, "## Annotation {} ({line_label})", i + 1);
         let body = entry.annotation.body.trim();
         match entry.annotation.anchor.kind() {
             Kind::Delete => {
-                out.push_str("Remove this\n");
+                out.push_str("Remove this:\n");
                 out.push_str(&fenced(quoted));
-                let _ = writeln!(
-                    out,
-                    "> {}",
-                    if body.is_empty() { "I don't want this in the plan." } else { body }
-                );
+                let _ = writeln!(out, "> {}", if body.is_empty() { "I don't want this." } else { body });
             }
             Kind::LooksGood => {
-                let _ = writeln!(out, "[Looks good] Feedback on: \"{}\"", single_line(quoted));
+                let _ = writeln!(out, "Looks good: \"{}\"", single_line(quoted));
                 if !body.is_empty() {
                     let _ = writeln!(out, "> {}", quote_lines(body));
                 }
             }
             Kind::Comment => {
-                let _ = writeln!(out, "Feedback on: \"{}\"", single_line(quoted));
+                let _ = writeln!(out, "Comment on: \"{}\"", single_line(quoted));
                 let _ = writeln!(out, "> {}", quote_lines(body));
             }
         }
@@ -123,12 +113,12 @@ mod tests {
             Entry { annotation: &comment, lines: line_span(source, &r1), range: r1 },
             Entry { annotation: &delete, lines: line_span(source, &r2), range: r2 },
         ];
-        let out = feedback(source, "plan", &entries);
+        let out = feedback(source, "plan.md", &entries);
         assert_eq!(
             out,
-            "# Plan Feedback\n\nI've reviewed this plan and have 2 pieces of feedback:\n\n\
-             ## 1. (line 3) Feedback on: \"login page\"\n> Which page?\n> Be specific.\n\n\
-             ## 2. (line 5) Remove this\n```\nDrop the `legacy` path.\n```\n> I don't want this in the plan.\n\n"
+            "# Annotations on plan.md\n\n\
+             ## Annotation 1 (line 3)\nComment on: \"login page\"\n> Which page?\n> Be specific.\n\n\
+             ## Annotation 2 (line 5)\nRemove this:\n```\nDrop the `legacy` path.\n```\n> I don't want this.\n\n"
         );
     }
 

--- a/crates/plannotator-tui/tests/folder_export.rs
+++ b/crates/plannotator-tui/tests/folder_export.rs
@@ -33,8 +33,9 @@ fn folder_export_includes_every_annotated_file() {
         .output()
         .expect("export runs");
     let text = String::from_utf8_lossy(&out.stdout);
-    assert!(text.contains("## File: a.md"), "{text}");
-    assert!(text.contains("## File: b.md"), "{text}");
+    assert!(text.contains("# Annotations on a.md"), "{text}");
+    assert!(text.contains("# Annotations on b.md"), "{text}");
+    assert!(text.contains("## Annotation 1 (line 3)"), "{text}");
     assert!(text.contains("\"alpha\"") && text.contains("\"beta\""), "{text}");
     std::fs::remove_dir_all(&root).expect("cleanup");
 }

--- a/docs/spec-herdr-integration.md
+++ b/docs/spec-herdr-integration.md
@@ -122,7 +122,7 @@ command = "plannotator-tui.last"
 > `herdr plugin pane open --plugin plannotator-tui --entrypoint doc --placement split
 > --direction right --target-pane "$HERDR_PANE_ID" --focus --env PLANNOTATOR_TUI_FILE=<path>
 > --env PLANNOTATOR_TUI_DELIVER_TO="$HERDR_PANE_ID"`, and **end your turn**. The review arrives
-> as your next user message, as numbered feedback (`## 1. (line 12) Feedback on: "…"`).
+> as your next user message, as numbered annotations (`# Annotations on <file>`, `## Annotation 1 (line 12)`).
 > Address each item. Only when `HERDR_ENV=1`.
 
 The agent never waits on plannotator-tui and never parses its output. Feedback is a normal turn.

--- a/docs/spec-local-storage.md
+++ b/docs/spec-local-storage.md
@@ -84,7 +84,7 @@ This slice adds:
 - **Tree that stays out of the way.** `t` hides/shows it; auto-hides under 120 columns;
   `Tab` still reaches it.
 - **Folder-wide export.** `E` in the tree copies feedback for every annotated file, with
-  a `## File: <path>` heading per file.
+  a `# Annotations on <path>` block per file.
 
 ## Not built
 

--- a/skills/plannotator-tui/SKILL.md
+++ b/skills/plannotator-tui/SKILL.md
@@ -21,7 +21,10 @@ file is and ask them to review it.
    user message, as numbered feedback:
 
    ```
-   ## 1. (line 12) Feedback on: "Rotate the token on every…"
+   # Annotations on docs/plans/auth.md
+
+   ## Annotation 1 (line 12)
+   Comment on: "Rotate the token on every…"
    > Rotation on every privilege change will log people out…
    ```
 


### PR DESCRIPTION
Export format: `# Annotations on <file>` with `## Annotation N (line X)` entries; skill and spec updated.