### PR TITLE
ci: publish crates to crates.io on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+# Publish the crates to crates.io once a release exists (binaries built, tag verified).
+# Runs when a GitHub release is published, or on demand for a given tag. Order matters:
+# the binary crate depends on the two libraries.
+name: publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "release tag to publish, e.g. v0.2.0"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  crates-io:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: tag matches Cargo.toml
+        run: |
+          version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+          tag="${{ inputs.tag || github.event.release.tag_name }}"
+          test "v$version" = "$tag" || { echo "tag $tag != v$version"; exit 1; }
+      - name: publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          for crate in plannotator-tui-schema plannotator-tui-hosts plannotator-tui; do
+            if cargo publish -p "$crate" 2> err.log; then
+              echo "published $crate"
+            elif grep -q "already exists\|already uploaded" err.log; then
+              echo "$crate: this version is already on crates.io; skipping"
+            else
+              cat err.log; exit 1
+            fi
+          done

--- a/crates/plannotator-tui-hosts/Cargo.toml
+++ b/crates/plannotator-tui-hosts/Cargo.toml
@@ -4,6 +4,8 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+keywords = ["annotation", "markdown", "agents"]
+categories = ["text-processing"]
 description = "Find a coding agent's transcript and read its recent messages (Claude Code, Codex)."
 
 [dependencies]

--- a/crates/plannotator-tui-schema/Cargo.toml
+++ b/crates/plannotator-tui-schema/Cargo.toml
@@ -4,6 +4,8 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+keywords = ["annotation", "markdown", "agents"]
+categories = ["text-processing"]
 description = "Annotation and anchor types shared by plannotator-tui and Plannotator Workspaces."
 
 [dependencies]

--- a/crates/plannotator-tui/Cargo.toml
+++ b/crates/plannotator-tui/Cargo.toml
@@ -5,14 +5,17 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Annotate Markdown in the terminal - standalone, and as a Herdr plugin."
+readme = "../../README.md"
+keywords = ["tui", "markdown", "annotation", "review", "agents"]
+categories = ["command-line-utilities", "text-processing"]
 
 [[bin]]
 name = "plannotator-tui"
 path = "src/main.rs"
 
 [dependencies]
-plannotator-tui-schema = { path = "../plannotator-tui-schema" }
-plannotator-tui-hosts = { path = "../plannotator-tui-hosts" }
+plannotator-tui-schema = { path = "../plannotator-tui-schema", version = "0.2.0" }
+plannotator-tui-hosts = { path = "../plannotator-tui-hosts", version = "0.2.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Crate metadata for crates.io, versioned path deps, and a publish workflow (on release published, or dispatch with a tag).