### PR TITLE
feat/last robustness

### DIFF
--- a/crates/plannotator-tui/src/app/mod.rs
+++ b/crates/plannotator-tui/src/app/mod.rs
@@ -260,6 +260,10 @@ impl App {
         Ok(())
     }
 
+    pub(crate) fn set_status(&mut self, status: String) {
+        self.status = Some(status);
+    }
+
     pub(crate) fn record_frame(&mut self, ms: f64) {
         self.frame_ms = if self.frame_ms == 0.0 { ms } else { self.frame_ms * 0.9 + ms * 0.1 };
         self.frame_max_ms = self.frame_max_ms.max(ms);

--- a/crates/plannotator-tui/src/cli.rs
+++ b/crates/plannotator-tui/src/cli.rs
@@ -182,17 +182,16 @@ fn herdr_command(args: &[String]) -> Result<()> {
 /// The pane entrypoint: Herdr runs this in the opened pane; the environment says what to show.
 fn herdr_pane() -> Result<()> {
     let env = HerdrEnv::from_env();
-    let result = match env.message_pid {
-        Some(pid) => crate::last::run(&crate::last::LastOptions {
+    let result = if let Some(pid) = env.message_pid {
+        crate::last::run(&crate::last::LastOptions {
             host: env.host.clone(),
             pid: Some(pid),
             pick: 25,
             ..crate::last::LastOptions::default()
-        }),
-        None => {
-            let path = env.file.clone().unwrap_or(std::env::current_dir().context("current directory")?);
-            interactive(&path)
-        }
+        })
+    } else {
+        let path = env.file.clone().unwrap_or(std::env::current_dir().context("current directory")?);
+        interactive(&path)
     };
     // The pane closes when we exit; an error that flashes by is an error nobody can read.
     if let Err(err) = &result {

--- a/crates/plannotator-tui/src/cli.rs
+++ b/crates/plannotator-tui/src/cli.rs
@@ -182,16 +182,28 @@ fn herdr_command(args: &[String]) -> Result<()> {
 /// The pane entrypoint: Herdr runs this in the opened pane; the environment says what to show.
 fn herdr_pane() -> Result<()> {
     let env = HerdrEnv::from_env();
-    if let Some(pid) = env.message_pid {
-        return crate::last::run(&crate::last::LastOptions {
-            host: env.host,
+    let result = match env.message_pid {
+        Some(pid) => crate::last::run(&crate::last::LastOptions {
+            host: env.host.clone(),
             pid: Some(pid),
             pick: 25,
             ..crate::last::LastOptions::default()
-        });
+        }),
+        None => {
+            let path = env.file.clone().unwrap_or(std::env::current_dir().context("current directory")?);
+            interactive(&path)
+        }
+    };
+    // The pane closes when we exit; an error that flashes by is an error nobody can read.
+    if let Err(err) = &result {
+        #[allow(clippy::print_stderr, reason = "the pane is the only place this can be read")]
+        {
+            eprintln!("plannotator-tui: {err:#}\n\npress enter to close");
+        }
+        let mut line = String::new();
+        let _ = std::io::stdin().read_line(&mut line);
     }
-    let path = env.file.unwrap_or(std::env::current_dir().context("current directory")?);
-    interactive(&path)
+    result
 }
 
 /// `plannotator-tui last [--host H] [--pid N] [--session PATH] [--stdin] [--print] [--pick N]`.

--- a/crates/plannotator-tui/src/herdr/launch.rs
+++ b/crates/plannotator-tui/src/herdr/launch.rs
@@ -49,22 +49,25 @@ pub(crate) fn agent_pid(process_info_json: &str) -> Option<(u32, String)> {
     let pid_of = |p: &serde_json::Value| p.get("pid").and_then(serde_json::Value::as_u64).map(|n| n as u32);
     for process in processes {
         let name = name_of(process);
-        if let Some(host) = host_for_process(&name) {
+        if let Some(host) = known_host(&name) {
             return pid_of(process).map(|pid| (pid, host.to_owned()));
         }
     }
+    // No process we can read: report the group leader under its own name, so the pane can
+    // say "<name> is not supported" and fall back to the screen.
     let leader = info.get("foreground_process_group_id").and_then(serde_json::Value::as_u64)?;
-    processes
-        .iter()
-        .find(|p| pid_of(p) == Some(leader as u32))
-        .and_then(pid_of)
-        .map(|pid| (pid, "claude".to_owned()))
+    let process = processes.iter().find(|p| pid_of(p) == Some(leader as u32))?;
+    let name = name_of(process);
+    let host = name.rsplit('/').next().unwrap_or(&name).to_owned();
+    pid_of(process).map(|pid| (pid, if host.is_empty() { "claude".to_owned() } else { host }))
 }
 
-fn host_for_process(name: &str) -> Option<&'static str> {
+/// Agents whose transcripts the hosts crate can read, by process name.
+fn known_host(name: &str) -> Option<&'static str> {
     match name.rsplit('/').next().unwrap_or(name) {
         "claude" => Some("claude"),
         "codex" => Some("codex"),
+        "pi" => Some("pi"),
         _ => None,
     }
 }
@@ -207,6 +210,7 @@ pub(crate) fn argv(launch: &Launch) -> Vec<String> {
         Some((pid, host)) => {
             out.extend(["--env".to_owned(), format!("PLANNOTATOR_TUI_MESSAGE_PID={pid}")]);
             out.extend(["--env".to_owned(), format!("PLANNOTATOR_TUI_HOST={host}")]);
+            out.extend(["--env".to_owned(), format!("PLANNOTATOR_TUI_CWD={}", launch.cwd.display())]);
         }
         None => out.extend(["--env".to_owned(), format!("PLANNOTATOR_TUI_FILE={}", launch.file.display())]),
     }

--- a/crates/plannotator-tui/src/herdr/launch/tests.rs
+++ b/crates/plannotator-tui/src/herdr/launch/tests.rs
@@ -166,12 +166,10 @@ const PROCESS_INFO: &str = r#"{"id":"cli:pane:process_info","result":{"process_i
 #[test]
 fn the_agent_pid_is_the_named_agent_process_else_the_group_leader() {
     assert_eq!(agent_pid(PROCESS_INFO), Some((91279, "claude".into())));
-    let leader_only = PROCESS_INFO.replace(r#""name":"claude""#, r#""name":"node""#);
-    assert_eq!(
-        agent_pid(&leader_only),
-        Some((91279, "claude".into())),
-        "unknown name → leader, host default"
-    );
+    let pi = PROCESS_INFO.replace(r#""name":"claude""#, r#""name":"pi""#);
+    assert_eq!(agent_pid(&pi), Some((91279, "pi".into())));
+    let unknown = PROCESS_INFO.replace(r#""name":"claude""#, r#""name":"aider""#);
+    assert_eq!(agent_pid(&unknown), Some((91279, "aider".into())), "unknown agents keep their name");
     assert_eq!(agent_pid("{}"), None);
 }
 

--- a/crates/plannotator-tui/src/last/locate.rs
+++ b/crates/plannotator-tui/src/last/locate.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 use plannotator_tui_hosts::{Host, HostError, Message, Role, claude, codex, detect_host};
+use plannotator_tui_schema::{DocumentSource, Provenance};
 
 use super::LastOptions;
 
@@ -55,6 +56,31 @@ fn host_for(options: &LastOptions) -> Result<Host> {
         }
         Err(err) => Err(err.into()),
     }
+}
+
+/// The agent pane's recent output as a document, when Herdr and a target pane are known.
+/// Lossy (no markdown structure survives a terminal), so only a fallback.
+pub(crate) fn screen_fallback(env: &crate::herdr::context::HerdrEnv) -> Option<DocumentSource> {
+    let target = env.delivery_target()?;
+    if !env.in_herdr {
+        return None;
+    }
+    let output = Command::new(&env.bin)
+        .args(["agent", "read", &target.pane, "--source", "recent-unwrapped", "--format", "text"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    let text = String::from_utf8_lossy(&output.stdout).trim_end().to_owned();
+    if text.is_empty() {
+        return None;
+    }
+    let host = env.host.clone().or(target.agent).unwrap_or_else(|| "agent".to_owned());
+    Some(DocumentSource::new(
+        text,
+        format!("{host} · screen"),
+        true,
+        Provenance::AgentMessage { host, session: None, message_id: None },
+    ))
 }
 
 fn home() -> PathBuf {

--- a/crates/plannotator-tui/src/last/mod.rs
+++ b/crates/plannotator-tui/src/last/mod.rs
@@ -52,7 +52,18 @@ pub(crate) fn run(options: &LastOptions) -> Result<()> {
             eprintln!("plannotator-tui last: {err:#}");
             return Ok(());
         }
-        Err(err) => return Err(err),
+        // Inside Herdr we can still show what the agent printed, whatever it is.
+        Err(err) => {
+            let Some(screen) = locate::screen_fallback(&crate::herdr::context::HerdrEnv::from_env()) else {
+                return Err(err);
+            };
+            let note = format!("{err:#} — showing the pane's recent output instead");
+            return cli::run_ui(|width| {
+                let mut app = App::open(screen, width, cli::delivery(true))?;
+                app.set_status(note.clone());
+                Ok(app)
+            });
+        }
     };
     if options.print {
         if let Some(newest) = located.messages.first() {


### PR DESCRIPTION
Pane errors stay on screen (no more flash); the launcher passes the real agent name and cwd; `last` falls back to the pane's recent output when the agent's transcript can't be read.