### PR TITLE
test(hosts): open transcripts for writing before setting mtime (windows)

### DIFF
--- a/crates/plannotator-tui-hosts/tests/ladder.rs
+++ b/crates/plannotator-tui-hosts/tests/ladder.rs
@@ -45,7 +45,8 @@ impl Home {
         let path = dir.join(format!("{session_id}.jsonl"));
         fs::write(&path, content).expect("transcript");
         let when = SystemTime::now() - Duration::from_secs(age_secs);
-        File::open(&path).expect("open").set_modified(when).expect("mtime");
+        // Windows needs write access to change a timestamp.
+        fs::OpenOptions::new().write(true).open(&path).expect("open").set_modified(when).expect("mtime");
         path
     }
 }

--- a/crates/plannotator-tui-hosts/tests/ladder.rs
+++ b/crates/plannotator-tui-hosts/tests/ladder.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::expect_used, clippy::indexing_slicing, reason = "tests assert by panicking")]
 
-use std::fs::{self, File};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 


### PR DESCRIPTION
Windows refuses set_modified on a read-only handle; the ladder test helper now opens for writing.