### PR TITLE
ci: notify the homebrew tap on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,3 +70,26 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release create "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --title "${GITHUB_REF_NAME}" --generate-notes dist/*
+
+  # Tell the Homebrew tap to regenerate its formula for this release. Skipped
+  # (never failed) when HOMEBREW_TAP_TOKEN is absent, e.g. on forks.
+  homebrew:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: dispatch to plannotator/homebrew-tap
+        env:
+          # The default GITHUB_TOKEN cannot reach another repository. This is a
+          # fine-grained PAT scoped to plannotator/homebrew-tap with
+          # "Contents: read and write" and "Metadata: read".
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "no HOMEBREW_TAP_TOKEN; skipping homebrew tap update"
+            exit 0
+          fi
+          version="${GITHUB_REF_NAME#v}"
+          gh api repos/plannotator/homebrew-tap/dispatches \
+            -f event_type=plannotator-tui-release \
+            -F "client_payload[version]=${version}"


### PR DESCRIPTION
Adds a final `homebrew` job to the release workflow that tells [plannotator/homebrew-tap](https://github.com/plannotator/homebrew-tap) to regenerate `Formula/plannotator-tui.rb` after a release publishes, so `brew install plannotator/tap/plannotator-tui` tracks new versions automatically.

The tap side is already in place: a `repository_dispatch` of type `plannotator-tui-release` triggers a workflow there that reads the release's `SHA256SUMS` and commits the regenerated formula.

### Requires a secret

The default `GITHUB_TOKEN` cannot reach another repository, so this uses `HOMEBREW_TAP_TOKEN` — a fine-grained PAT scoped to `plannotator/homebrew-tap` with **Contents: read and write** and **Metadata: read**.

Until that secret exists the step logs `no HOMEBREW_TAP_TOKEN; skipping homebrew tap update` and exits 0, so releases never fail because the secret is missing. The check is at step level rather than in a job-level `if:`, since `secrets` is not reliably available in job-level conditions.