### PR TITLE
ci: publish to crates.io inside the release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,8 @@
-# Publish the crates to crates.io once a release exists (binaries built, tag verified).
-# Runs when a GitHub release is published, or on demand for a given tag. Order matters:
-# the binary crate depends on the two libraries.
+# On-demand crates.io publish for a given tag (the release workflow publishes on its own;
+# this exists for re-runs). Order matters: the binary crate depends on the two libraries.
 name: publish
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -25,13 +22,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || inputs.tag || github.event.release.tag_name }}
+          ref: ${{ inputs.ref || inputs.tag }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: tag matches Cargo.toml
         run: |
           version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
-          tag="${{ inputs.tag || github.event.release.tag_name }}"
+          tag="${{ inputs.tag }}"
           test "v$version" = "$tag" || { echo "tag $tag != v$version"; exit 1; }
       - name: publish
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,30 @@ jobs:
 
   # Tell the Homebrew tap to regenerate its formula for this release. Skipped
   # (never failed) when HOMEBREW_TAP_TOKEN is absent, e.g. on forks.
+  crates-io:
+    # A release created with the workflow token does not fire `release: published` for
+    # other workflows, so publishing happens here, after the binaries are up.
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          for crate in plannotator-tui-schema plannotator-tui-hosts plannotator-tui; do
+            if cargo publish -p "$crate" 2> err.log; then
+              echo "published $crate"
+            elif grep -q "already exists\|already uploaded" err.log; then
+              echo "$crate: this version is already on crates.io; skipping"
+            else
+              cat err.log; exit 1
+            fi
+          done
+
   homebrew:
     needs: publish
     runs-on: ubuntu-latest


### PR DESCRIPTION
A workflow-token release does not trigger `release: published`, so crates.io publishing now runs as a job of the release workflow after the binaries are up. publish.yml stays for re-runs.