### PR TITLE
test(hosts): backticks in the windows-only doc comment (clippy doc_markdown)

### DIFF
--- a/crates/plannotator-tui-hosts/tests/copilot.rs
+++ b/crates/plannotator-tui-hosts/tests/copilot.rs
@@ -42,7 +42,7 @@ impl CopilotHome {
 }
 
 /// A handle that can change a directory's mtime. Windows needs write access and
-/// FILE_FLAG_BACKUP_SEMANTICS to open a directory at all.
+/// `FILE_FLAG_BACKUP_SEMANTICS` to open a directory at all.
 #[cfg(windows)]
 fn open_dir_for_mtime(dir: &Path) -> std::io::Result<File> {
     use std::os::windows::fs::OpenOptionsExt as _;


### PR DESCRIPTION
Windows-only cfg block; clippy doc_markdown only runs there.