### PR TITLE
docs: readme — install, use, herdr, agent replies, data, headless

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,70 @@
 <img src="docs/assets/banner.webp" alt="Plannotator TUI" width="720">
 
-Annotate Markdown in the terminal: select text, comment, 👍 looks good, ✗ delete.
-A standalone app, and a Herdr plugin that knows how to open it.
+Annotate Markdown in the terminal. Select text, leave a 💬 comment, mark it 👍 looks good or
+✗ delete, and hand the review to a coding agent as numbered feedback. One static binary,
+no runtime. Rust + ratatui.
 
-- `crates/plannotator-tui-schema` - annotation and anchor types, wire-compatible with
-  Plannotator Workspaces (phase 1).
-- `crates/plannotator-tui` - the TUI application.
-- `herdr/` - the Herdr plugin manifest; `skills/` - the agent skill.
-- `samples/` - documents for development and benchmarks.
+[![crates.io](https://img.shields.io/crates/v/plannotator-tui?style=flat-square)](https://crates.io/crates/plannotator-tui)
+[![release](https://img.shields.io/github/v/release/plannotator/plannotator-tui?style=flat-square)](https://github.com/plannotator/plannotator-tui/releases)
+[![ci](https://img.shields.io/github/actions/workflow/status/plannotator/plannotator-tui/post-merge.yml?branch=main&style=flat-square&label=main)](https://github.com/plannotator/plannotator-tui/actions/workflows/post-merge.yml)
 
-## Run
+```text
+                                                                             Copy 2 as feedback
+  Herdr plugins are shareable, executable workflow packages. A
+  plugin can be a Bash script, JavaScript app, Lua script, Rust
+▍ binary, or any other argv command your machine can run. Herdr     ╭ 💬  8d3e8 ────────────────╮
+▍ owns the host surface: installation, manifest validation,         │ Say which parts the      │
+  keybindings, terminal panes, events, invocation context, and      │ plugin can override.     │
+  socket access. The plugin owns its implementation language,       ╰──────────────────────────╯
+  dependencies, files, and durable state.
+    👍  looks good (a)  💬  comment (c)  ✗ delete (d)
+▍ Plugins exist so Herdr can stay lean. The core stays focused on   ╭ 👍  25300 ────────────────╮
+▍ terminal workspaces, panes, agents, and a stable CLI/socket API.  │ looks good               │
+▍ Plugins turn that existing extension surface into reusable        ╰──────────────────────────╯
+▍ workflows that people can build, install, and share without
+▍ adding every workflow to Herdr itself.
 
-```bash
-cargo build --release
-./target/release/plannotator-tui samples/plugins.md
+ plugins.md · 2 annotations · selected 36 chars a looks good · c comment · d delete · esc clear
 ```
+
+Watch it inside Herdr: [demo](https://x.com/plannotator/status/2093419561077154287).
+
+## Install
+
+```sh
+brew install plannotator/tap/plannotator-tui     # macOS, Linux
+cargo install plannotator-tui                    # anywhere with Rust
+```
+
+Prebuilt binaries for macOS, Linux and Windows are on the
+[releases page](https://github.com/plannotator/plannotator-tui/releases).
+
+## Use
+
+```sh
+plannotator-tui docs/plan.md      # one file
+plannotator-tui docs               # a folder: file tree on the left, counts per file
+plannotator-tui last               # your coding agent's recent replies, pick one, annotate it
+```
+
+Drag with the mouse (or `v` and move) to select, then `a` 👍 · `c` 💬 · `d` ✗. `E` copies the
+review to the clipboard as numbered annotations (`# Annotations on plan.md`, `## Annotation 1
+(line 12)`, …). Every annotation is saved as JSON the moment you make it; `q` closes.
+
+| Where | Keys |
+|---|---|
+| anywhere | `Tab` cycle tree · document · notes; `E` send; `t` tree; `r` reload; `q` quit |
+| document | `j`/`k` block; `c` comment on the block; `x` clear its annotations; `v` select with `hjkl` `w` `b` `0` `$` |
+| toolbar | `a` looks good · `c` comment · `d` delete · `Esc` |
+| notes | `j`/`k`; `e` edit; `x` remove; click a bubble |
+| tree | `j`/`k`; `Enter` open; `E` sends every annotated file |
 
 ## Inside Herdr
 
-Link the plugin once (`herdr plugin link ./herdr`), build it (`cargo build --release`), and
-bind a key:
-
-```toml
-# ~/.config/herdr/config.toml
-[[keys.command]]
-key = "prefix+a"
-type = "plugin_action"
-command = "plannotator-tui.open"
-
-[[keys.command]]
-key = "prefix+shift+d"
-type = "plugin_action"
-command = "plannotator-tui.last"
-```
-
-`prefix+a` opens the focused pane's folder for review; Ctrl-click on a `file://…md` link an
-agent printed opens that file; an agent runs `plannotator-tui herdr open <file>` from its own pane
-(see `skills/plannotator-tui/SKILL.md`). In every case the header button says where feedback goes
-— `Send 3 to claude in w1:p2 ▸` — and clicking it (or `E`) makes the review the agent's next
-message. Where plannotator-tui opens is yours to choose:
+Install [Herdr Annotate](https://github.com/plannotator/herdr-annotate); it bundles this binary,
+opens it in a pane with `prefix+o` (folder) or `prefix+shift+o` (agent's last reply) or by
+Ctrl-clicking a `file://…md` link, and the header button sends the review straight back to
+the agent as its next message: `Send 3 to claude in w1:p2 ▸`.
 
 ```toml
 # ~/.config/plannotator-tui/config.toml
@@ -46,18 +72,43 @@ message. Where plannotator-tui opens is yours to choose:
 placement = "overlay"   # overlay (full tab, default) | split | popup
 ```
 
-`plannotator-tui config` prints the file's path and the values in effect.
+`plannotator-tui config` prints the file's path and the values in effect. The `herdr/`
+directory in this repo is the development manifest; users should install Herdr Annotate.
 
-## Review the agent's last message
+## Agent replies
 
-`plannotator-tui last` finds the transcript of the agent that launched your shell (Claude
-Code, Codex, pi, GitHub Copilot CLI, or Droid), shows a picker of its recent replies, and opens
-the one you choose as a
-document you can annotate and send back — nothing is written to disk. In Herdr, bind
-`plannotator-tui.last` (`prefix+shift+d` above) and press it in the agent's pane. For
-scripts and hooks, `plannotator-tui last --print` writes the newest reply to stdout and
-always exits 0; `--session <transcript>` skips detection and `--stdin` reads a document
-from stdin.
+`plannotator-tui last` finds the transcript of the agent that launched your shell and shows a
+picker of its recent replies. Hosts: Claude Code, Codex, pi, GitHub Copilot CLI, Droid.
+`--host`, `--pid`, `--session <transcript>` override detection; `--stdin` reads a document;
+`--print` writes the newest reply to stdout and always exits 0 (for hooks and scripts).
+Reply reviews are never written to disk.
 
-See `crates/plannotator-tui/README.md` for keys, headless tools, and measurements;
-`docs/decisions.md` for the design record; `AGENTS.md` for engineering rules.
+## Where annotations live
+
+```
+~/.plannotator/clients/plannotator-tui/annotations/<project>/<slug>/annotations.json
+```
+
+`<project>` is the git repo name, `<slug>` the file's basename plus 8 hex of the sha256 of
+its path: Plannotator's own layout, so both tools see one record per file. The JSON is the
+Plannotator Workspaces wire shape; any agent can read it. Nothing is written next to your
+files. `PLANNOTATOR_DATA_DIR` relocates the directory.
+
+## Headless
+
+```sh
+plannotator-tui --export <file|folder>                          # the review, to stdout
+plannotator-tui --annotate <file> <quote> <text> [comment|looks_good|delete]
+plannotator-tui --snapshot <file|folder> [cols rows scroll] [quote]   # one frame as text
+plannotator-tui --bench <file>                                  # parse / layout timings
+```
+
+## Repository
+
+- `crates/plannotator-tui`: the app. `crates/plannotator-tui-schema`: annotation and anchor
+  types, wire-compatible with Plannotator Workspaces. `crates/plannotator-tui-hosts`: agent
+  transcript readers.
+- `docs/decisions.md` is the design record; `AGENTS.md` the engineering rules;
+  `crates/plannotator-tui/README.md` the full key reference and measurements.
+
+MIT.


### PR DESCRIPTION
Root README rewritten: install lines, a captured frame, demo link, keys, Herdr pointer (Herdr Annotate), agent replies, data location, headless tools.