### PR TITLE
ci: windows clippy in the pr gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
-# Pull-request gate. One runner, one job, cancelled when the PR is updated, so a burst of
-# PRs never queues behind each other. Cross-platform and release builds run after merge.
+# Pull-request gate: fmt + clippy + tests on Ubuntu, and clippy alone on Windows (cfg(windows)
+# code is invisible to clippy elsewhere). Both jobs run in parallel and are cancelled when the
+# PR is updated. Full cross-platform tests and release builds run after merge.
 name: ci
 
 on:
@@ -26,3 +27,14 @@ jobs:
       - run: cargo fmt --all --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace
+
+  check-windows:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace --all-targets -- -D warnings


### PR DESCRIPTION
Three Windows-only lints reached main this week because clippy on macOS/Linux never compiles cfg(windows) code. A parallel check-only Windows job in the gate catches them before merge.