### PR TITLE
fix: scroll the file tree to keep the selected row visible

### DIFF
--- a/crates/plannotator-tui/src/app/draw.rs
+++ b/crates/plannotator-tui/src/app/draw.rs
@@ -83,6 +83,8 @@ impl App {
 
         self.draw_header(frame, header);
         if show_tree {
+            // A resize may have changed the tree's height; keep the window in range.
+            self.tree_scroll_by(0);
             self.draw_tree(frame, tree);
         }
         self.draw_document(frame, gutter, doc);
@@ -114,6 +116,7 @@ impl App {
             .rows
             .iter()
             .enumerate()
+            .skip(self.tree_scroll)
             .take(usize::from(inner.height))
             .map(|(i, row)| {
                 let indent = "  ".repeat(row.depth);

--- a/crates/plannotator-tui/src/app/input.rs
+++ b/crates/plannotator-tui/src/app/input.rs
@@ -87,7 +87,7 @@ impl App {
     }
 
     fn tree_key(&mut self, key: KeyEvent) -> Result<()> {
-        let len = self.tree.as_ref().map_or(0, |t| t.rows.len());
+        let len = self.tree_len();
         match key.code {
             KeyCode::Char('j') | KeyCode::Down => {
                 self.tree_cursor = (self.tree_cursor + 1).min(len.saturating_sub(1));
@@ -97,6 +97,8 @@ impl App {
             KeyCode::Esc => self.focus = Focus::Document,
             _ => {}
         }
+        // The tree's height is the last frame's; the first frame has not drawn yet, but its cursor is row 0.
+        self.keep_tree_cursor_visible(usize::from(self.geometry.tree.height));
         Ok(())
     }
 
@@ -286,6 +288,8 @@ impl App {
 
     fn mouse(&mut self, mouse: MouseEvent) -> Result<()> {
         match mouse.kind {
+            MouseEventKind::ScrollDown if self.in_tree(mouse.column, mouse.row) => self.tree_scroll_by(3),
+            MouseEventKind::ScrollUp if self.in_tree(mouse.column, mouse.row) => self.tree_scroll_by(-3),
             MouseEventKind::ScrollDown => self.scroll_by(3),
             MouseEventKind::ScrollUp => self.scroll_by(-3),
             MouseEventKind::Down(MouseButton::Left) => {
@@ -352,16 +356,17 @@ impl App {
         spans.iter().zip(TOOLBAR.iter()).find(|(span, _)| span.contains(&column)).map(|(_, item)| item.3)
     }
 
-    fn tree_hit(&self, row: u16, column: u16) -> Option<usize> {
+    /// Whether the screen cell is inside the drawn tree pane.
+    fn in_tree(&self, column: u16, row: u16) -> bool {
         let tree = self.geometry.tree;
-        let inside = tree.width > 0
-            && column >= tree.x
-            && column < tree.right()
-            && row >= tree.y
-            && row < tree.bottom();
-        inside
-            .then(|| usize::from(row - tree.y))
-            .filter(|&i| self.tree.as_ref().is_some_and(|t| i < t.rows.len()))
+        tree.width > 0 && column >= tree.x && column < tree.right() && row >= tree.y && row < tree.bottom()
+    }
+
+    /// The tree row under the screen cell, accounting for the tree's scroll offset.
+    fn tree_hit(&self, row: u16, column: u16) -> Option<usize> {
+        self.in_tree(column, row)
+            .then(|| self.tree_scroll + usize::from(row - self.geometry.tree.y))
+            .filter(|&i| i < self.tree_len())
     }
 
     fn bubble_hit(&self, column: u16, row: u16) -> Option<usize> {

--- a/crates/plannotator-tui/src/app/mod.rs
+++ b/crates/plannotator-tui/src/app/mod.rs
@@ -114,6 +114,8 @@ pub(crate) struct App {
     /// Present in folder mode.
     tree: Option<Tree>,
     tree_cursor: usize,
+    /// First tree row drawn; follows `tree_cursor` so the selected row stays visible.
+    tree_scroll: usize,
     /// `t` toggles; `None` means "automatic by width".
     tree_visible: Option<bool>,
     delivery: Box<dyn Delivery>,
@@ -168,6 +170,7 @@ impl App {
             project,
             tree: None,
             tree_cursor: 0,
+            tree_scroll: 0,
             tree_visible: None,
             delivery,
             send_state,
@@ -439,6 +442,30 @@ impl App {
         let height = usize::from(self.geometry.doc.height.max(1));
         let max = self.open.layout.total_rows.saturating_sub(height);
         self.scroll = (self.scroll as i64 + delta).clamp(0, max as i64) as usize;
+    }
+
+    fn tree_len(&self) -> usize {
+        self.tree.as_ref().map_or(0, |t| t.rows.len())
+    }
+
+    /// Scroll the tree by `delta` rows without moving its cursor (mouse wheel over the tree).
+    fn tree_scroll_by(&mut self, delta: i64) {
+        let height = usize::from(self.geometry.tree.height.max(1));
+        let max = self.tree_len().saturating_sub(height);
+        self.tree_scroll = (self.tree_scroll as i64 + delta).clamp(0, max as i64) as usize;
+    }
+
+    /// Move the tree's window so `tree_cursor` is inside its `height` visible rows.
+    fn keep_tree_cursor_visible(&mut self, height: usize) {
+        if height == 0 {
+            return;
+        }
+        if self.tree_cursor < self.tree_scroll {
+            self.tree_scroll = self.tree_cursor;
+        } else if self.tree_cursor >= self.tree_scroll + height {
+            self.tree_scroll = self.tree_cursor + 1 - height;
+        }
+        self.tree_scroll = self.tree_scroll.min(self.tree_len().saturating_sub(height));
     }
 
     /// Re-read the document from its provenance and re-resolve every annotation.

--- a/crates/plannotator-tui/src/app/tests.rs
+++ b/crates/plannotator-tui/src/app/tests.rs
@@ -136,3 +136,92 @@ fn escaping_the_picker_keeps_the_newest_message() {
     app.handle_event(&Event::Key(KeyEvent::from(KeyCode::Char('p')))).expect("p");
     assert_eq!(app.mode, Mode::Pick, "p reopens the picker");
 }
+
+/// A folder of `count` Markdown files named `f00.md`, `f01.md`, … in a fresh temp dir.
+fn folder(count: usize) -> PathBuf {
+    let root = std::env::temp_dir().join(format!("plannotator-tui-folder-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).expect("mkdir");
+    for i in 0..count {
+        std::fs::write(root.join(format!("f{i:02}.md")), format!("# File {i}\n")).expect("write");
+    }
+    root
+}
+
+/// One frame at `width` × `height`, as one string per screen row.
+fn draw_sized(app: &mut App, width: u16, height: u16) -> Vec<String> {
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
+    terminal.draw(|frame| app.draw(frame)).expect("draw");
+    let buffer = terminal.backend().buffer();
+    (0..buffer.area.height)
+        .map(|y| {
+            (0..buffer.area.width)
+                .filter_map(|x| buffer.cell((x, y)))
+                .map(|c| c.symbol().to_owned())
+                .collect()
+        })
+        .collect()
+}
+
+fn open_path(app: &App) -> String {
+    match &app.open.source.provenance {
+        Provenance::File { path } => path.file_name().expect("name").to_string_lossy().into_owned(),
+        _ => String::new(),
+    }
+}
+
+#[test]
+fn the_tree_scrolls_to_keep_the_cursor_visible_and_hit_tests_through_the_offset() {
+    let root = folder(30);
+    let mut app = App::open_folder(&root, 100, Box::new(Discard)).expect("folder opens");
+    // 140 columns shows the tree; 20 rows leaves 18 for the body (header + footer).
+    draw_sized(&mut app, 140, 20);
+    app.handle_event(&Event::Key(KeyEvent::from(KeyCode::Tab))).expect("tab");
+    for _ in 0..25 {
+        app.handle_event(&Event::Key(KeyEvent::from(KeyCode::Char('j')))).expect("j");
+    }
+    assert_eq!(app.tree_cursor, 25);
+    let rows = draw_sized(&mut app, 140, 20);
+    assert_eq!(app.tree_scroll, 8, "the window slides so row 25 is the last visible row");
+    assert!(row(&rows, 1).contains("f08.md"), "first drawn tree row was {:?}", row(&rows, 1));
+    assert!(row(&rows, 18).contains("f25.md"), "last drawn tree row was {:?}", row(&rows, 18));
+    let tree_pane: Vec<String> = rows[1..=18].iter().map(|r| r.chars().take(28).collect()).collect();
+    assert!(!tree_pane.iter().any(|r| r.contains("f00.md")), "tree pane was {tree_pane:#?}");
+
+    // Clicking the third visible row opens the file at scroll + 2, not row 2.
+    let click = Event::Mouse(MouseEvent {
+        kind: MouseEventKind::Down(MouseButton::Left),
+        column: 2,
+        row: 3,
+        modifiers: KeyModifiers::NONE,
+    });
+    app.handle_event(&click).expect("click");
+    assert_eq!(app.tree_cursor, 10);
+    assert_eq!(open_path(&app), "f10.md");
+
+    // Moving back up pulls the window with the cursor.
+    app.handle_event(&Event::Key(KeyEvent::from(KeyCode::Tab))).expect("tab");
+    for _ in 0..5 {
+        app.handle_event(&Event::Key(KeyEvent::from(KeyCode::Char('k')))).expect("k");
+    }
+    draw_sized(&mut app, 140, 20);
+    assert_eq!((app.tree_cursor, app.tree_scroll), (5, 5));
+
+    // The wheel over the tree scrolls the tree, not the document, and leaves the cursor alone.
+    let wheel = Event::Mouse(MouseEvent {
+        kind: MouseEventKind::ScrollDown,
+        column: 2,
+        row: 5,
+        modifiers: KeyModifiers::NONE,
+    });
+    app.handle_event(&wheel).expect("wheel");
+    assert_eq!((app.tree_cursor, app.tree_scroll, app.scroll), (5, 8, 0));
+    // Wheel scrolling is clamped to the last full window of rows.
+    for _ in 0..20 {
+        app.handle_event(&wheel).expect("wheel");
+    }
+    assert_eq!(app.tree_scroll, 12, "30 rows in 18 lines: the window stops at 12");
+    let rows = draw_sized(&mut app, 140, 20);
+    assert!(row(&rows, 18).contains("f29.md"), "last tree row was {:?}", row(&rows, 18));
+    std::fs::remove_dir_all(&root).expect("cleanup");
+}


### PR DESCRIPTION
Fixes the tree navigator rendering only its first viewport (#34).

- `tree_scroll` offset follows the cursor on `j`/`k`/arrows and is re-clamped on resize
- `draw_tree` renders from the offset; `tree_hit` maps clicks through it
- mouse wheel over the tree scrolls the tree, not the document, without moving the cursor
- regression test in folder mode: 30 files in an 18-row body, navigate past the fold, click through the offset, wheel-scroll and clamp

refs #34

https://claude.ai/code/session_01L232F8ev8RX6Jwd7PepsUz