### PR TITLE
fix(tree): keep navigator selection visible

### DIFF
--- a/crates/plannotator-tui/src/app/draw.rs
+++ b/crates/plannotator-tui/src/app/draw.rs
@@ -99,7 +99,8 @@ impl App {
         }
     }
 
-    fn draw_tree(&self, frame: &mut Frame, area: Rect) {
+    fn draw_tree(&mut self, frame: &mut Frame, area: Rect) {
+        self.set_tree_scroll(self.tree_scroll);
         let Some(tree) = &self.tree else { return };
         let focused = self.focus == Focus::Tree;
         let border = if focused { Style::new().fg(Color::Cyan) } else { Style::new().fg(Color::DarkGray) };
@@ -114,6 +115,7 @@ impl App {
             .rows
             .iter()
             .enumerate()
+            .skip(self.tree_scroll)
             .take(usize::from(inner.height))
             .map(|(i, row)| {
                 let indent = "  ".repeat(row.depth);

--- a/crates/plannotator-tui/src/app/input.rs
+++ b/crates/plannotator-tui/src/app/input.rs
@@ -93,10 +93,11 @@ impl App {
                 self.tree_cursor = (self.tree_cursor + 1).min(len.saturating_sub(1));
             }
             KeyCode::Char('k') | KeyCode::Up => self.tree_cursor = self.tree_cursor.saturating_sub(1),
-            KeyCode::Enter | KeyCode::Char('l') | KeyCode::Right => self.open_tree_selection()?,
+            KeyCode::Enter | KeyCode::Char('l') | KeyCode::Right => return self.open_tree_selection(),
             KeyCode::Esc => self.focus = Focus::Document,
-            _ => {}
+            _ => return Ok(()),
         }
+        self.ensure_tree_cursor_visible();
         Ok(())
     }
 
@@ -286,6 +287,12 @@ impl App {
 
     fn mouse(&mut self, mouse: MouseEvent) -> Result<()> {
         match mouse.kind {
+            MouseEventKind::ScrollDown if self.tree_contains(mouse.row, mouse.column) => {
+                self.scroll_tree(3, true);
+            }
+            MouseEventKind::ScrollUp if self.tree_contains(mouse.row, mouse.column) => {
+                self.scroll_tree(3, false);
+            }
             MouseEventKind::ScrollDown => self.scroll_by(3),
             MouseEventKind::ScrollUp => self.scroll_by(-3),
             MouseEventKind::Down(MouseButton::Left) => {
@@ -352,16 +359,15 @@ impl App {
         spans.iter().zip(TOOLBAR.iter()).find(|(span, _)| span.contains(&column)).map(|(_, item)| item.3)
     }
 
-    fn tree_hit(&self, row: u16, column: u16) -> Option<usize> {
+    fn tree_contains(&self, row: u16, column: u16) -> bool {
         let tree = self.geometry.tree;
-        let inside = tree.width > 0
-            && column >= tree.x
-            && column < tree.right()
-            && row >= tree.y
-            && row < tree.bottom();
-        inside
-            .then(|| usize::from(row - tree.y))
-            .filter(|&i| self.tree.as_ref().is_some_and(|t| i < t.rows.len()))
+        tree.width > 0 && column >= tree.x && column < tree.right() && row >= tree.y && row < tree.bottom()
+    }
+
+    fn tree_hit(&self, row: u16, column: u16) -> Option<usize> {
+        self.tree_contains(row, column)
+            .then(|| self.tree_scroll + usize::from(row - self.geometry.tree.y))
+            .filter(|&index| self.tree.as_ref().is_some_and(|tree| index < tree.rows.len()))
     }
 
     fn bubble_hit(&self, column: u16, row: u16) -> Option<usize> {

--- a/crates/plannotator-tui/src/app/mod.rs
+++ b/crates/plannotator-tui/src/app/mod.rs
@@ -114,6 +114,7 @@ pub(crate) struct App {
     /// Present in folder mode.
     tree: Option<Tree>,
     tree_cursor: usize,
+    tree_scroll: usize,
     /// `t` toggles; `None` means "automatic by width".
     tree_visible: Option<bool>,
     delivery: Box<dyn Delivery>,
@@ -168,6 +169,7 @@ impl App {
             project,
             tree: None,
             tree_cursor: 0,
+            tree_scroll: 0,
             tree_visible: None,
             delivery,
             send_state,
@@ -235,6 +237,30 @@ impl App {
         if shown && self.focus == Focus::Tree {
             self.focus = Focus::Document;
         }
+    }
+
+    fn set_tree_scroll(&mut self, scroll: usize) {
+        let len = self.tree.as_ref().map_or(0, |tree| tree.rows.len());
+        let viewport = usize::from(self.geometry.tree.height);
+        self.tree_scroll = scroll.min(len.saturating_sub(viewport));
+    }
+
+    fn ensure_tree_cursor_visible(&mut self) {
+        let viewport = usize::from(self.geometry.tree.height);
+        if viewport == 0 {
+            return;
+        }
+        if self.tree_cursor < self.tree_scroll {
+            self.set_tree_scroll(self.tree_cursor);
+        } else if self.tree_cursor >= self.tree_scroll.saturating_add(viewport) {
+            self.set_tree_scroll(self.tree_cursor + 1 - viewport);
+        }
+    }
+
+    fn scroll_tree(&mut self, rows: usize, down: bool) {
+        let scroll =
+            if down { self.tree_scroll.saturating_add(rows) } else { self.tree_scroll.saturating_sub(rows) };
+        self.set_tree_scroll(scroll);
     }
 
     /// Switch to the file under the tree cursor.

--- a/crates/plannotator-tui/src/app/tests.rs
+++ b/crates/plannotator-tui/src/app/tests.rs
@@ -3,6 +3,7 @@
 
 #![allow(clippy::expect_used, clippy::indexing_slicing, reason = "tests assert by panicking")]
 
+use std::fs::{create_dir_all, remove_dir_all, write};
 use std::path::PathBuf;
 
 use plannotator_tui_schema::{DocumentSource, Kind, Provenance};
@@ -135,4 +136,60 @@ fn escaping_the_picker_keeps_the_newest_message() {
     assert_eq!(app.open.source.name, "claude · last message");
     app.handle_event(&Event::Key(KeyEvent::from(KeyCode::Char('p')))).expect("p");
     assert_eq!(app.mode, Mode::Pick, "p reopens the picker");
+}
+
+fn folder_app() -> (App, PathBuf) {
+    let root = std::env::temp_dir().join(format!("plannotator-tui-tree-scroll-{}", std::process::id()));
+    let _ = remove_dir_all(&root);
+    create_dir_all(&root).expect("mkdir");
+    for index in 0..24 {
+        write(root.join(format!("{index:02}.md")), "# File\n").expect("write");
+    }
+    let mut app = App::open_folder(&root, 60, Box::new(Discard)).expect("opens folder");
+    app.focus = super::Focus::Tree;
+    (app, root)
+}
+
+#[test]
+fn tree_cursor_scrolls_into_view() {
+    let (mut app, root) = folder_app();
+    draw(&mut app);
+    for _ in 0..20 {
+        app.handle_event(&Event::Key(KeyEvent::from(KeyCode::Char('j')))).expect("j");
+    }
+
+    assert_eq!(app.tree_cursor, 20);
+    assert_eq!(app.tree_scroll, 3);
+    let rows = draw(&mut app);
+    let tree_rows: Vec<&String> = rows.iter().skip(1).take(18).collect();
+    assert!(tree_rows.iter().any(|row| row.contains("20.md")), "{tree_rows:?}");
+    assert!(!tree_rows.iter().any(|row| row.contains("00.md")), "{tree_rows:?}");
+    remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+fn mouse_scrolling_over_tree_updates_visible_rows_and_click_target() {
+    let (mut app, root) = folder_app();
+    draw(&mut app);
+    let tree = app.geometry.tree;
+    let scroll = Event::Mouse(MouseEvent {
+        kind: MouseEventKind::ScrollDown,
+        column: tree.x,
+        row: tree.y,
+        modifiers: KeyModifiers::NONE,
+    });
+    app.handle_event(&scroll).expect("scroll");
+    assert_eq!(app.tree_scroll, 3);
+    let rows = draw(&mut app);
+    assert!(rows.iter().any(|row| row.contains("03.md")), "{rows:?}");
+
+    let click = Event::Mouse(MouseEvent {
+        kind: MouseEventKind::Down(MouseButton::Left),
+        column: tree.x,
+        row: tree.y,
+        modifiers: KeyModifiers::NONE,
+    });
+    app.handle_event(&click).expect("click");
+    assert_eq!(app.open.source.name, "03.md");
+    remove_dir_all(root).expect("cleanup");
 }


### PR DESCRIPTION
Fixes #34.

The folder navigator now tracks a viewport offset. Keyboard movement scrolls the file list to keep its selected row visible; mouse-wheel input over the tree scrolls that same list; and clicks resolve through the current offset.

The regression tests cover keyboard navigation past the initial viewport and selecting a row after mouse scrolling.

Validation:
- `cargo fmt --all --check`
- `cargo test -p plannotator-tui`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `plannotator-tui --bench samples/big.md` (no material rendering regression observed)