### PR TITLE
feat(hosts): opencode transcripts from its sqlite database

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ directory in this repo is the development manifest; users should install Herdr A
 
 `plannotator-tui last` finds the transcript of the agent that launched your shell and shows a
 picker of its recent replies. Hosts: Claude Code, Codex, pi, Oh My Pi, GitHub Copilot CLI,
-Droid, Hermes CLI. `--host`, `--pid`, `--session <transcript>` (format sniffed when no host is
-named) and `--session-id <id>` (Hermes) override detection; `--stdin` reads a document;
+Droid, Hermes CLI, OpenCode. `--host`, `--pid`, `--session <transcript>` (format sniffed when
+no host is named) and `--session-id <id>` (Hermes, OpenCode) override detection; `--stdin`
+reads a document;
 `--print` writes the newest reply to stdout and always exits 0 (for hooks and scripts).
 Reply reviews are never written to disk.
 

--- a/crates/plannotator-tui-hosts/src/hermes.rs
+++ b/crates/plannotator-tui-hosts/src/hermes.rs
@@ -5,12 +5,15 @@
 
 use std::path::Path;
 
-use rusqlite::{Connection, OpenFlags, params};
+use rusqlite::params;
 
+use crate::sqlite::{open_read_only, sql_error};
 use crate::{HostError, Message, Role};
 
 /// The database relative to `$HERMES_HOME` (default `~/.hermes`).
 pub const DB_FILE: &str = "state.db";
+
+const WHAT: &str = "Hermes";
 
 /// The newest `n` user and assistant messages of `session_id`, newest first.
 ///
@@ -18,10 +21,7 @@ pub const DB_FILE: &str = "state.db";
 /// live WAL; when the shared-memory index cannot be opened, the read falls back to
 /// `immutable=1`, which reads the main file only and may lag an active writer.
 pub fn messages_for_session(db: &Path, session_id: &str, n: usize) -> Result<Vec<Message>, HostError> {
-    if !db.is_file() {
-        return Err(HostError::NoTranscript(format!("no Hermes database at {}", db.display())));
-    }
-    let connection = open_read_only(db)?;
+    let connection = open_read_only(db, WHAT)?;
     let mut statement = connection
         .prepare(
             "SELECT id, role, content, timestamp FROM messages \
@@ -29,7 +29,7 @@ pub fn messages_for_session(db: &Path, session_id: &str, n: usize) -> Result<Vec
              AND content IS NOT NULL AND trim(content) <> '' \
              ORDER BY timestamp DESC, id DESC LIMIT ?2",
         )
-        .map_err(|e| sql_error(&e))?;
+        .map_err(|e| sql_error(WHAT, &e))?;
     let rows = statement
         .query_map(params![session_id, n as i64], |row| {
             let id: i64 = row.get(0)?;
@@ -38,10 +38,10 @@ pub fn messages_for_session(db: &Path, session_id: &str, n: usize) -> Result<Vec
             let timestamp: Option<f64> = row.get(3)?;
             Ok((id, role, content, timestamp))
         })
-        .map_err(|e| sql_error(&e))?;
+        .map_err(|e| sql_error(WHAT, &e))?;
     let mut messages = Vec::new();
     for row in rows {
-        let (id, role, content, timestamp) = row.map_err(|e| sql_error(&e))?;
+        let (id, role, content, timestamp) = row.map_err(|e| sql_error(WHAT, &e))?;
         let Some(text) = content.filter(|c| !c.trim().is_empty()) else { continue };
         let role = match role.as_str() {
             "assistant" => Role::Assistant,
@@ -59,28 +59,8 @@ pub fn messages_for_session(db: &Path, session_id: &str, n: usize) -> Result<Vec
     Ok(messages)
 }
 
-fn open_read_only(db: &Path) -> Result<Connection, HostError> {
-    let flags =
-        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX | OpenFlags::SQLITE_OPEN_URI;
-    let uri = |query: &str| format!("file:{}?{query}", db.display());
-    match Connection::open_with_flags(uri("mode=ro"), flags) {
-        Ok(connection) if probe(&connection) => Ok(connection),
-        _ => Connection::open_with_flags(uri("mode=ro&immutable=1"), flags).map_err(|e| sql_error(&e)),
-    }
-}
-
-/// A read-only WAL open can succeed and still fail on first read when the `-shm` cannot be
-/// mapped; probe once so the fallback happens before any query.
-fn probe(connection: &Connection) -> bool {
-    connection.query_row("SELECT count(*) FROM sqlite_master", [], |row| row.get::<_, i64>(0)).is_ok()
-}
-
 /// Hermes stamps rows in Unix seconds (REAL).
 fn iso(seconds: f64) -> String {
     let ms = if seconds.is_finite() && seconds >= 0.0 { (seconds * 1000.0) as u64 } else { 0 };
     crate::time::iso_from_unix_ms(ms)
-}
-
-fn sql_error(err: &rusqlite::Error) -> HostError {
-    HostError::NoTranscript(format!("reading the Hermes database: {err}"))
 }

--- a/crates/plannotator-tui-hosts/src/lib.rs
+++ b/crates/plannotator-tui-hosts/src/lib.rs
@@ -11,7 +11,9 @@ pub mod copilot;
 pub mod droid;
 pub mod hermes;
 pub mod omp;
+pub mod opencode;
 pub mod pi;
+pub(crate) mod sqlite;
 pub(crate) mod time;
 
 use std::path::PathBuf;
@@ -30,6 +32,9 @@ pub enum Host {
     Omp,
     /// Hermes CLI: conversations in `SQLite` (`~/.hermes/state.db`), addressed by session id.
     Hermes,
+    /// `OpenCode`: sessions, messages and parts in `SQLite` (`<xdg data>/opencode/opencode.db`),
+    /// addressed by session id or found by the directory `OpenCode` was started in.
+    OpenCode,
 }
 
 impl Host {
@@ -43,12 +48,21 @@ impl Host {
             Self::Pi => "pi",
             Self::Omp => "omp",
             Self::Hermes => "hermes",
+            Self::OpenCode => "opencode",
         }
     }
 
     /// Every host with a transcript reader, for messages that list them.
-    pub const ALL: [Host; 7] =
-        [Host::ClaudeCode, Host::Codex, Host::Pi, Host::Omp, Host::Copilot, Host::Droid, Host::Hermes];
+    pub const ALL: [Host; 8] = [
+        Host::ClaudeCode,
+        Host::Codex,
+        Host::Pi,
+        Host::Omp,
+        Host::Copilot,
+        Host::Droid,
+        Host::Hermes,
+        Host::OpenCode,
+    ];
 }
 
 /// Which reader a transcript file wants, from its first lines. For a path handed to us
@@ -147,6 +161,7 @@ pub fn detect_host(env: impl Fn(&str) -> Option<String>) -> Result<Host, HostErr
             "pi" => return Ok(Host::Pi),
             "omp" | "oh-my-pi" | "ohmypi" => return Ok(Host::Omp),
             "hermes" | "hermes-cli" | "hermes_cli" => return Ok(Host::Hermes),
+            "opencode" | "open-code" | "open_code" => return Ok(Host::OpenCode),
             _ => {}
         }
     }
@@ -167,10 +182,11 @@ pub fn detect_host(env: impl Fn(&str) -> Option<String>) -> Result<Host, HostErr
     if ai_agent.as_deref() == Some("pi") || set("PI_CODING_AGENT") {
         return Ok(Host::Pi);
     }
-    for (key, name) in [("OPENCODE", "OpenCode"), ("GEMINI_CLI", "Gemini CLI")] {
-        if set(key) {
-            return Err(HostError::Unsupported(name.to_owned()));
-        }
+    if set("OPENCODE") {
+        return Ok(Host::OpenCode);
+    }
+    if set("GEMINI_CLI") {
+        return Err(HostError::Unsupported("Gemini CLI".to_owned()));
     }
     if set("OMPCODE") {
         return Ok(Host::Omp);

--- a/crates/plannotator-tui-hosts/src/opencode.rs
+++ b/crates/plannotator-tui-hosts/src/opencode.rs
@@ -1,0 +1,152 @@
+//! `OpenCode`: sessions, messages and parts live in `SQLite` (`opencode.db` under the XDG data
+//! dir), one row per message and one per part, with the payload as JSON in `data`.
+//!
+//! Verified against opencode 1.18 source (`packages/core/src/database/database.ts`,
+//! `packages/core/src/global.ts`, `packages/opencode/src/session/message-v2.ts`):
+//!
+//! - the database is `$OPENCODE_DB`, else `<xdg data>/opencode/opencode.db`, where the xdg
+//!   data dir is `$XDG_DATA_HOME` or `~/.local/share` on every platform;
+//! - `session.directory` is where `OpenCode` was started; child sessions (subagents) carry a
+//!   `parent_id`; archived sessions carry `time_archived`;
+//! - a message's text is its `part` rows of type `text`, in id order; parts flagged
+//!   `synthetic` or `ignored` are injected context, not something the user or model wrote.
+
+use std::path::Path;
+
+use rusqlite::params;
+
+use crate::sqlite::{open_read_only, sql_error};
+use crate::{HostError, Message, Role};
+
+/// The database relative to `OpenCode`'s data directory.
+pub const DB_FILE: &str = "opencode.db";
+/// The data directory relative to the XDG data home.
+pub const DATA_DIR: &str = "opencode";
+
+const WHAT: &str = "OpenCode";
+
+/// The newest top-level, unarchived session started in `cwd`. When none was started exactly
+/// there, the newest one started in an ancestor of `cwd` (`OpenCode` records the directory it
+/// was launched from; the pane may have moved since).
+pub fn find_session(db: &Path, cwd: &Path) -> Result<String, HostError> {
+    let connection = open_read_only(db, WHAT)?;
+    let mut statement = connection
+        .prepare(
+            "SELECT id, directory FROM session \
+             WHERE parent_id IS NULL AND time_archived IS NULL \
+             ORDER BY time_updated DESC",
+        )
+        .map_err(|e| sql_error(WHAT, &e))?;
+    let rows = statement
+        .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))
+        .map_err(|e| sql_error(WHAT, &e))?;
+    let cwd = normalize(&cwd.to_string_lossy());
+    let mut ancestor: Option<String> = None;
+    for row in rows {
+        let (id, directory) = row.map_err(|e| sql_error(WHAT, &e))?;
+        let directory = normalize(&directory);
+        if directory == cwd {
+            return Ok(id);
+        }
+        if ancestor.is_none() && is_ancestor(&directory, &cwd) {
+            ancestor = Some(id);
+        }
+    }
+    ancestor
+        .ok_or_else(|| HostError::NoTranscript(format!("no OpenCode session for {cwd} in {}", db.display())))
+}
+
+/// The newest `n` user and assistant messages of `session_id` that carry text, newest first.
+pub fn messages_for_session(db: &Path, session_id: &str, n: usize) -> Result<Vec<Message>, HostError> {
+    let connection = open_read_only(db, WHAT)?;
+    // One indexed pass: every text part of the session, grouped by message, newest message
+    // first and parts in creation order within it.
+    let mut statement = connection
+        .prepare(
+            "SELECT m.id, m.data, p.data FROM message m \
+             JOIN part p ON p.message_id = m.id \
+             WHERE m.session_id = ?1 AND json_extract(p.data, '$.type') = 'text' \
+             ORDER BY m.time_created DESC, m.id DESC, p.time_created ASC, p.id ASC",
+        )
+        .map_err(|e| sql_error(WHAT, &e))?;
+    let rows = statement
+        .query_map(params![session_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+        })
+        .map_err(|e| sql_error(WHAT, &e))?;
+
+    let mut messages: Vec<Message> = Vec::new();
+    let mut current: Option<(String, Role, Option<String>, Vec<String>)> = None;
+    let flush = |current: &mut Option<(String, Role, Option<String>, Vec<String>)>,
+                 out: &mut Vec<Message>| {
+        if let Some((id, role, at, parts)) = current.take()
+            && !parts.is_empty()
+        {
+            out.push(Message { id, role, text: parts.join("\n\n"), at });
+        }
+    };
+    for row in rows {
+        let (id, message_data, part_data) = row.map_err(|e| sql_error(WHAT, &e))?;
+        if current.as_ref().is_none_or(|c| c.0 != id) {
+            flush(&mut current, &mut messages);
+            if messages.len() >= n {
+                break;
+            }
+            let Some((role, at)) = message_meta(&message_data) else { continue };
+            current = Some((id, role, at, Vec::new()));
+        }
+        if let Some((_, _, _, parts)) = current.as_mut()
+            && let Some(text) = part_text(&part_data)
+        {
+            parts.push(text);
+        }
+    }
+    if messages.len() < n {
+        flush(&mut current, &mut messages);
+    }
+    if messages.is_empty() {
+        return Err(HostError::NoMessages(format!(
+            "no messages for OpenCode session {session_id} in {}",
+            db.display()
+        )));
+    }
+    Ok(messages)
+}
+
+/// Role and creation time from a `message.data` payload; `None` for roles we do not render.
+fn message_meta(data: &str) -> Option<(Role, Option<String>)> {
+    let json: serde_json::Value = serde_json::from_str(data).ok()?;
+    let role = match json.get("role").and_then(|r| r.as_str())? {
+        "assistant" => Role::Assistant,
+        "user" => Role::Human,
+        _ => return None,
+    };
+    let at =
+        json.pointer("/time/created").and_then(serde_json::Value::as_u64).map(crate::time::iso_from_unix_ms);
+    Some((role, at))
+}
+
+/// The text of a `part.data` payload when it is real text: type `text`, not `synthetic`
+/// (injected by `OpenCode`), not `ignored`, not empty.
+fn part_text(data: &str) -> Option<String> {
+    let json: serde_json::Value = serde_json::from_str(data).ok()?;
+    if json.get("type").and_then(|t| t.as_str()) != Some("text") {
+        return None;
+    }
+    let flagged = |key: &str| json.get(key).and_then(serde_json::Value::as_bool).unwrap_or(false);
+    if flagged("synthetic") || flagged("ignored") {
+        return None;
+    }
+    let text = json.get("text").and_then(|t| t.as_str())?;
+    (!text.trim().is_empty()).then(|| text.to_owned())
+}
+
+/// Paths compare without a trailing separator; Windows drive letters case-insensitively.
+fn normalize(path: &str) -> String {
+    let trimmed = path.trim_end_matches(['/', '\\']);
+    if cfg!(windows) { trimmed.replace('\\', "/").to_ascii_lowercase() } else { trimmed.to_owned() }
+}
+
+fn is_ancestor(directory: &str, cwd: &str) -> bool {
+    !directory.is_empty() && cwd.starts_with(directory) && cwd.as_bytes().get(directory.len()) == Some(&b'/')
+}

--- a/crates/plannotator-tui-hosts/src/sqlite.rs
+++ b/crates/plannotator-tui-hosts/src/sqlite.rs
@@ -1,0 +1,33 @@
+//! Read-only `SQLite` access shared by the store-backed hosts (Hermes, `OpenCode`).
+
+use std::path::Path;
+
+use rusqlite::{Connection, OpenFlags};
+
+use crate::HostError;
+
+/// Open `db` read-only, never writing. A plain read-only open sees the live WAL; when the
+/// shared-memory index cannot be opened, fall back to `immutable=1`, which reads the main
+/// file only and may lag an active writer.
+pub(crate) fn open_read_only(db: &Path, what: &str) -> Result<Connection, HostError> {
+    if !db.is_file() {
+        return Err(HostError::NoTranscript(format!("no {what} database at {}", db.display())));
+    }
+    let flags =
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX | OpenFlags::SQLITE_OPEN_URI;
+    let uri = |query: &str| format!("file:{}?{query}", db.display());
+    match Connection::open_with_flags(uri("mode=ro"), flags) {
+        Ok(connection) if probe(&connection) => Ok(connection),
+        _ => Connection::open_with_flags(uri("mode=ro&immutable=1"), flags).map_err(|e| sql_error(what, &e)),
+    }
+}
+
+/// A read-only WAL open can succeed and still fail on first read when the `-shm` cannot be
+/// mapped; probe once so the fallback happens before any query.
+fn probe(connection: &Connection) -> bool {
+    connection.query_row("SELECT count(*) FROM sqlite_master", [], |row| row.get::<_, i64>(0)).is_ok()
+}
+
+pub(crate) fn sql_error(what: &str, err: &rusqlite::Error) -> HostError {
+    HostError::NoTranscript(format!("reading the {what} database: {err}"))
+}

--- a/crates/plannotator-tui-hosts/tests/detect.rs
+++ b/crates/plannotator-tui-hosts/tests/detect.rs
@@ -33,7 +33,7 @@ fn the_override_wins_when_it_names_a_known_host_and_is_ignored_otherwise() {
 fn codex_marker_beats_unsupported_markers_which_are_reported_not_hidden() {
     assert_eq!(detect_host(env(&[("CODEX_THREAD_ID", "t"), ("OMPCODE", "1")])).expect("host"), Host::Codex);
     assert!(matches!(detect_host(env(&[("GEMINI_CLI", "1")])), Err(HostError::Unsupported(_))));
-    assert!(matches!(detect_host(env(&[("OPENCODE", "1")])), Err(HostError::Unsupported(_))));
+    assert_eq!(detect_host(env(&[("OPENCODE", "1")])).expect("opencode"), Host::OpenCode);
 }
 
 #[test]
@@ -52,6 +52,7 @@ fn omp_is_selected_by_its_name_first_and_by_ompcode_last() {
     ));
     assert_eq!(detect_host(env(&[("PLANNOTATOR_TUI_HOST", "oh-my-pi")])).expect("host"), Host::Omp);
     assert_eq!(detect_host(env(&[("PLANNOTATOR_TUI_HOST", "hermes")])).expect("host"), Host::Hermes);
+    assert_eq!(detect_host(env(&[("PLANNOTATOR_TUI_HOST", "opencode")])).expect("host"), Host::OpenCode);
 }
 
 #[test]
@@ -74,5 +75,6 @@ fn labels_are_the_short_names_herdr_uses() {
     assert_eq!(Host::Pi.label(), "pi");
     assert_eq!(Host::Omp.label(), "omp");
     assert_eq!(Host::Hermes.label(), "hermes");
-    assert_eq!(Host::ALL.len(), 7);
+    assert_eq!(Host::OpenCode.label(), "opencode");
+    assert_eq!(Host::ALL.len(), 8);
 }

--- a/crates/plannotator-tui-hosts/tests/opencode.rs
+++ b/crates/plannotator-tui-hosts/tests/opencode.rs
@@ -1,0 +1,158 @@
+//! `OpenCode` messages out of a generated `opencode.db` (the 1.18 schema subset), read-only.
+
+#![allow(clippy::expect_used, clippy::indexing_slicing, clippy::panic, reason = "tests assert by panicking")]
+
+use std::path::{Path, PathBuf};
+
+use plannotator_tui_hosts::{HostError, Role, opencode};
+use rusqlite::{Connection, params};
+
+const SCHEMA: &str = "
+CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT, slug TEXT NOT NULL,
+    directory TEXT NOT NULL, title TEXT NOT NULL, version TEXT NOT NULL,
+    time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, time_archived INTEGER);
+CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL,
+    time_updated INTEGER NOT NULL, data TEXT NOT NULL);
+CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL,
+    time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL);
+CREATE INDEX message_session_time_created_id_idx ON message (session_id, time_created, id);
+CREATE INDEX part_message_id_id_idx ON part (message_id, id);
+";
+
+fn temp_dir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("plannotator-tui-opencode-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    dir
+}
+
+fn session(c: &Connection, id: &str, dir: &str, parent: Option<&str>, updated: i64, archived: Option<i64>) {
+    c.execute(
+        "INSERT INTO session (id, project_id, parent_id, slug, directory, title, version, time_created, time_updated, time_archived) \
+         VALUES (?1, 'p', ?2, ?1, ?3, ?1, '1.18.23', ?4, ?4, ?5)",
+        params![id, parent, dir, updated, archived],
+    )
+    .expect("session");
+}
+
+fn message(c: &Connection, id: &str, session: &str, created: i64, role: &str) {
+    let data =
+        format!(r#"{{"id":"{id}","sessionID":"{session}","role":"{role}","time":{{"created":{created}}}}}"#);
+    c.execute(
+        "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?1, ?2, ?3, ?3, ?4)",
+        params![id, session, created, data],
+    )
+    .expect("message");
+}
+
+fn part(c: &Connection, id: &str, message: &str, created: i64, data: &str) {
+    c.execute(
+        "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?1, ?2, 's', ?3, ?3, ?4)",
+        params![id, message, created, data],
+    )
+    .expect("part");
+}
+
+/// One project with a main session, a newer child (subagent) session and a newer archived
+/// session; another project elsewhere. The main session's messages exercise every skip rule.
+fn populate(db: &Path) -> Connection {
+    let c = Connection::open(db).expect("create");
+    c.pragma_update(None, "journal_mode", "WAL").expect("wal");
+    c.execute_batch(SCHEMA).expect("schema");
+    session(&c, "ses_main", "/work/app", None, 1000, None);
+    session(&c, "ses_older", "/work/app", None, 900, None);
+    session(&c, "ses_child", "/work/app", Some("ses_main"), 2000, None);
+    session(&c, "ses_archived", "/work/app", None, 3000, Some(3000));
+    session(&c, "ses_other", "/work/other", None, 5000, None);
+    session(&c, "ses_root", "/work", None, 100, None);
+
+    message(&c, "msg_1", "ses_main", 10, "user");
+    part(&c, "prt_1a", "msg_1", 10, r#"{"type":"text","text":"first question"}"#);
+    part(
+        &c,
+        "prt_1b",
+        "msg_1",
+        11,
+        r#"{"type":"text","text":"<system-reminder>injected</system-reminder>","synthetic":true}"#,
+    );
+    message(&c, "msg_2", "ses_main", 20, "assistant");
+    part(&c, "prt_2a", "msg_2", 20, r#"{"type":"step-start"}"#);
+    part(&c, "prt_2b", "msg_2", 21, r#"{"type":"reasoning","text":"**thinking**"}"#);
+    part(&c, "prt_2c", "msg_2", 22, r#"{"type":"text","text":"oldest reply, part one"}"#);
+    part(&c, "prt_2d", "msg_2", 23, r#"{"type":"tool","tool":"read","state":{"status":"completed"}}"#);
+    part(&c, "prt_2e", "msg_2", 24, r#"{"type":"text","text":"oldest reply, part two"}"#);
+    part(&c, "prt_2f", "msg_2", 25, r#"{"type":"step-finish"}"#);
+    message(&c, "msg_3", "ses_main", 30, "assistant"); // aborted: no text at all
+    part(&c, "prt_3a", "msg_3", 30, r#"{"type":"step-start"}"#);
+    message(&c, "msg_4", "ses_main", 40, "user");
+    part(&c, "prt_4a", "msg_4", 40, r#"{"type":"text","text":"ignored draft","ignored":true}"#);
+    part(&c, "prt_4b", "msg_4", 41, r#"{"type":"text","text":"second question"}"#);
+    message(&c, "msg_5", "ses_main", 50, "assistant");
+    part(&c, "prt_5a", "msg_5", 50, r#"{"type":"text","text":"   "}"#);
+    part(&c, "prt_5b", "msg_5", 51, r#"{"type":"text","text":"newest reply"}"#);
+    message(&c, "msg_x", "ses_other", 60, "assistant");
+    part(&c, "prt_xa", "msg_x", 60, r#"{"type":"text","text":"other project"}"#);
+    c
+}
+
+#[test]
+fn newest_session_for_the_directory_skips_children_and_archived_ones() {
+    let dir = temp_dir("find");
+    let db = dir.join("opencode.db");
+    let writer = populate(&db);
+    assert_eq!(opencode::find_session(&db, Path::new("/work/app")).expect("exact"), "ses_main");
+    assert_eq!(opencode::find_session(&db, Path::new("/work/app/")).expect("trailing slash"), "ses_main");
+    // Started in an ancestor: the newest session there, never a sibling project.
+    assert_eq!(opencode::find_session(&db, Path::new("/work/app/src/deep")).expect("nested"), "ses_main");
+    assert_eq!(opencode::find_session(&db, Path::new("/work/tools")).expect("root"), "ses_root");
+    assert_eq!(opencode::find_session(&db, Path::new("/work/other")).expect("other"), "ses_other");
+    match opencode::find_session(&db, Path::new("/elsewhere")) {
+        Err(HostError::NoTranscript(msg)) => assert!(msg.contains("/elsewhere"), "{msg}"),
+        other => panic!("expected NoTranscript, got {other:?}"),
+    }
+    drop(writer);
+    std::fs::remove_dir_all(&dir).expect("cleanup");
+}
+
+#[test]
+fn text_parts_join_in_order_and_injected_or_empty_ones_are_skipped() {
+    let dir = temp_dir("read");
+    let db = dir.join("opencode.db");
+    let writer = populate(&db);
+    let messages = opencode::messages_for_session(&db, "ses_main", 25).expect("messages");
+    let texts: Vec<&str> = messages.iter().map(|m| m.text.as_str()).collect();
+    assert_eq!(
+        texts,
+        [
+            "newest reply",
+            "second question",
+            "oldest reply, part one\n\noldest reply, part two",
+            "first question"
+        ]
+    );
+    assert_eq!(messages[0].role, Role::Assistant);
+    assert_eq!(messages[0].id, "msg_5");
+    assert_eq!(messages[0].at.as_deref(), Some("1970-01-01T00:00:00.050Z"));
+    assert_eq!(messages[1].role, Role::Human);
+    // n counts messages with text; the aborted assistant turn does not consume a slot.
+    let two = opencode::messages_for_session(&db, "ses_main", 2).expect("two");
+    assert_eq!(two.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(), ["msg_5", "msg_4"]);
+    match opencode::messages_for_session(&db, "ses_empty", 25) {
+        Err(HostError::NoMessages(msg)) => assert!(msg.contains("ses_empty"), "{msg}"),
+        other => panic!("expected NoMessages, got {other:?}"),
+    }
+    drop(writer);
+    std::fs::remove_dir_all(&dir).expect("cleanup");
+}
+
+#[test]
+fn a_missing_database_is_reported_not_created() {
+    let dir = temp_dir("missing");
+    let db = dir.join("opencode.db");
+    match opencode::find_session(&db, Path::new("/work/app")) {
+        Err(HostError::NoTranscript(msg)) => assert!(msg.contains("no OpenCode database"), "{msg}"),
+        other => panic!("expected NoTranscript, got {other:?}"),
+    }
+    assert!(!db.exists(), "a read must not create the database");
+    std::fs::remove_dir_all(&dir).expect("cleanup");
+}

--- a/crates/plannotator-tui/src/cli.rs
+++ b/crates/plannotator-tui/src/cli.rs
@@ -33,7 +33,7 @@ const USAGE: &str = "usage:
   plannotator-tui herdr open [file.md | folder] [--placement overlay|split|popup] [--deliver-to <pane>]
   plannotator-tui herdr last [--placement P] [--deliver-to <pane>]
   plannotator-tui herdr pane
-  plannotator-tui last [--host claude|codex|pi|omp|copilot|droid|hermes] [--pid N] [--session <transcript>]
+  plannotator-tui last [--host claude|codex|pi|omp|copilot|droid|hermes|opencode] [--pid N] [--session <transcript>]
                        [--session-id <id>] [--stdin] [--print] [--pick N]";
 
 /// Width the document gets when nothing else is known: gutter + rail + gap subtracted.

--- a/crates/plannotator-tui/src/herdr/launch.rs
+++ b/crates/plannotator-tui/src/herdr/launch.rs
@@ -89,6 +89,7 @@ fn known_host(name: &str) -> Option<&'static str> {
         "claude" => Some("claude"),
         "codex" => Some("codex"),
         "pi" => Some("pi"),
+        "opencode" => Some("opencode"),
         _ => None,
     }
 }

--- a/crates/plannotator-tui/src/last/locate.rs
+++ b/crates/plannotator-tui/src/last/locate.rs
@@ -6,7 +6,8 @@ use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 use plannotator_tui_hosts::{
-    Host, HostError, Message, Role, claude, codex, copilot, detect_host, droid, hermes, omp, pi, sniff,
+    Host, HostError, Message, Role, claude, codex, copilot, detect_host, droid, hermes, omp, opencode, pi,
+    sniff,
 };
 use plannotator_tui_schema::{DocumentSource, Provenance};
 
@@ -74,6 +75,15 @@ pub(crate) fn locate(options: &LastOptions) -> Result<Located> {
             let db =
                 std::env::var_os("HERMES_HOME").map_or_else(hermes_home, PathBuf::from).join(hermes::DB_FILE);
             let messages = hermes::messages_for_session(&db, id, pick)?;
+            (db, messages)
+        }
+        (Host::OpenCode, _) => {
+            let db = opencode_db();
+            let id = match options.session_id.as_deref().filter(|s| !s.trim().is_empty()) {
+                Some(id) => id.to_owned(),
+                None => opencode::find_session(&db, &agent_cwd()?)?,
+            };
+            let messages = opencode::messages_for_session(&db, &id, pick)?;
             (db, messages)
         }
     };
@@ -162,6 +172,19 @@ fn hermes_home() -> PathBuf {
 #[cfg(not(windows))]
 fn hermes_home() -> PathBuf {
     home().join(".hermes")
+}
+
+/// `OpenCode`'s database: `$OPENCODE_DB`, else `<xdg data>/opencode/opencode.db` where the
+/// xdg data dir is `$XDG_DATA_HOME` or `~/.local/share` (opencode `packages/core/src/global.ts`
+/// uses `xdg-basedir`, which applies the same rule on every platform).
+fn opencode_db() -> PathBuf {
+    if let Some(db) = std::env::var_os("OPENCODE_DB").filter(|v| !v.is_empty()) {
+        return PathBuf::from(db);
+    }
+    let data = std::env::var_os("XDG_DATA_HOME")
+        .filter(|v| !v.is_empty())
+        .map_or_else(|| home().join(".local").join("share"), PathBuf::from);
+    data.join(opencode::DATA_DIR).join(opencode::DB_FILE)
 }
 
 fn home() -> PathBuf {

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -329,3 +329,21 @@ Source-verified 2026-08-29 against `NousResearch/hermes-agent` (`hermes_state_co
 the session id Herdr reports is `sessions.id`; `HERMES_HOME` else `~/.hermes`
 (`%LOCALAPPDATA%\hermes` on Windows). omp exports only `OMPCODE=1` and `CLAUDECODE=1` to
 child shells, no pi marker, so the marker chain reaches `OMPCODE` correctly.
+
+**OpenCode** (2026-08-29). OpenCode 1.x keeps sessions, messages and parts in one SQLite
+database, not transcript files: `$OPENCODE_DB`, else `<xdg data>/opencode/opencode.db` where
+the xdg data dir is `$XDG_DATA_HOME` or `~/.local/share` on every platform (`packages/core/src/global.ts`
+uses `xdg-basedir`, which has no Windows branch; `packages/core/src/database/database.ts`
+names the file). A message's text is its `part` rows of type `text` in creation order;
+parts flagged `synthetic` (context OpenCode injects) or `ignored` are not something the user
+or model wrote and are skipped, as are `reasoning`, `tool` and `step-*` parts, so an
+aborted assistant turn with no text does not take a picker slot. Herdr's OpenCode manifest
+carries no session id, so the reader picks the newest top-level (`parent_id IS NULL`,
+subagent sessions excluded), unarchived (`time_archived IS NULL`) session whose
+`session.directory` equals the agent pane's cwd (`PLANNOTATOR_TUI_CWD`), falling back to the
+newest session started in an ancestor of that cwd, since OpenCode records its launch
+directory and the pane may have moved. `--session-id` addresses a session directly. The
+database is opened read-only exactly as for Hermes (shared opener, `mode=ro` then
+`immutable=1`); one query joins `message` and `part` newest-message-first. `OPENCODE=1` in the
+environment now selects this host instead of reporting it unsupported. Verified live against
+opencode 1.18.23 (`~/.local/share/opencode/opencode.db`, 45 MB, WAL) on 2026-08-29.


### PR DESCRIPTION
Adds OpenCode as a `last` host.

- Database: `$OPENCODE_DB`, else `<xdg data>/opencode/opencode.db` (`$XDG_DATA_HOME` or `~/.local/share`), read-only (`mode=ro`, `immutable=1` fallback), opener shared with Hermes.
- Session: newest top-level (`parent_id IS NULL`), unarchived session whose `directory` equals the pane's cwd, else the newest one started in an ancestor of it; `--session-id` addresses one directly.
- Text: `part` rows of type `text` joined in creation order; `synthetic`, `ignored` and empty parts skipped; aborted turns take no picker slot.
- Detection: `--host opencode`, `PLANNOTATOR_TUI_HOST=opencode`, the `opencode` process name in Herdr, or `OPENCODE=1`.

Source-verified against opencode 1.18 (`packages/core/src/global.ts`, `database/database.ts`, `session/message-v2.ts`) and run live against a 45 MB WAL database from opencode 1.18.23. Tests generate the schema subset and cover session selection, part joining, skip rules, n, and the missing-database case.

https://claude.ai/code/session_01L232F8ev8RX6Jwd7PepsUz