### PR TITLE
fix(herdr): trust reported agent host

### DIFF
--- a/crates/plannotator-tui/src/herdr/launch.rs
+++ b/crates/plannotator-tui/src/herdr/launch.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result};
+use plannotator_tui_hosts::Host;
 
 use super::context::{HerdrEnv, Target};
 use crate::config::{Config, Placement, SplitDirection};
@@ -59,6 +60,13 @@ pub(crate) fn agent_session(agent_get_json: &str) -> Option<AgentSession> {
     }
 }
 
+/// Parse `herdr agent get <pane>` JSON for a host with a transcript reader.
+fn agent_host(agent_get_json: &str) -> Option<&'static str> {
+    let json: serde_json::Value = serde_json::from_str(agent_get_json).ok()?;
+    let label = json.pointer("/result/agent/agent")?.as_str()?;
+    Host::ALL.into_iter().find(|host| host.label() == label).map(Host::label)
+}
+
 /// The agent process behind a pane, from `herdr pane process-info --pane <id>` JSON: the
 /// foreground process whose name is a known agent, else the group leader. Returns
 /// `(pid, host)` where host is the label `plannotator-tui last --host` accepts.
@@ -109,11 +117,12 @@ pub(crate) fn plan_last(
     let Some(pane) = pane else {
         anyhow::bail!("no agent pane to read: not focused on one and no --deliver-to")
     };
-    let Some(message) = agent_pid(process_info_json) else {
+    let Some((pid, process_host)) = agent_pid(process_info_json) else {
         anyhow::bail!("no agent process found in pane {pane}");
     };
+    let host = agent_get_json.and_then(agent_host).unwrap_or(&process_host).to_owned();
     launch.file.clone_from(&launch.cwd);
-    launch.message = Some(message);
+    launch.message = Some((pid, host));
     launch.session = agent_get_json.and_then(agent_session);
     Ok(launch)
 }

--- a/crates/plannotator-tui/src/herdr/launch/tests.rs
+++ b/crates/plannotator-tui/src/herdr/launch/tests.rs
@@ -200,6 +200,32 @@ fn a_last_launch_carries_the_pid_and_host_instead_of_a_file() {
 
 const AGENT_GET_PATH: &str = r#"{"id":"cli:agent:get","result":{"agent":{"agent":"omp","agent_session":{"agent":"omp","kind":"path","source":"herdr:omp","value":"~/.omp/agent/sessions/--w--/2026-08-29T01-00-00-000Z_0199.jsonl"},"pane_id":"w1:p1"},"type":"agent_info"}}"#;
 const AGENT_GET_ID: &str = r#"{"id":"cli:agent:get","result":{"agent":{"agent":"hermes","agent_session":{"agent":"hermes","kind":"id","source":"herdr:hermes","value":"sess_abc123"},"pane_id":"w1:p1"},"type":"agent_info"}}"#;
+const AGENT_GET_PI: &str = r#"{"id":"cli:agent:get","result":{"agent":{"agent":"pi","agent_session":{"agent":"pi","kind":"path","source":"herdr:pi","value":"~/.pi/agent/sessions/--w--/session.jsonl"},"pane_id":"w1:p1"},"type":"agent_info"}}"#;
+
+#[test]
+fn herdrs_agent_label_wins_when_an_agent_runs_through_node() {
+    let process_info = PROCESS_INFO
+        .replace(r#""argv0":"claude""#, r#""argv0":"pi""#)
+        .replace(r#""name":"claude""#, r#""name":"node""#);
+    let context = HerdrContext {
+        focused_pane_id: Some("w1:p1".into()),
+        focused_pane_agent: Some("pi".into()),
+        focused_pane_cwd: Some("/w".into()),
+        ..HerdrContext::default()
+    };
+    let launch = plan_last(
+        &env(None, Some(context)),
+        &Config::default(),
+        OpenArgs::default(),
+        Path::new("/"),
+        &process_info,
+        Some(AGENT_GET_PI),
+    )
+    .expect("plans");
+
+    assert_eq!(launch.message, Some((91279, "pi".into())));
+    assert!(argv(&launch).contains(&"PLANNOTATOR_TUI_HOST=pi".to_owned()));
+}
 
 #[test]
 fn herdrs_agent_session_is_passed_to_the_pane_as_a_path_or_an_id() {


### PR DESCRIPTION
## What changed

Pi installed through npm runs as a Node process. Herdr already reports the pane agent as pi and provides the exact Pi session, but the launcher used the operating-system process name instead. That made Annotate open with the node host and could fall back to Claude.

Use Herdr’s supported agent label for transcript selection while keeping the real process PID. Unsupported labels retain the existing process-name fallback.

## Reproduction

- Herdr 0.8.2 reports agent: pi for the focused pane.
- pane process-info reports argv0: pi, name: node.
- Before this change, PLANNOTATOR_TUI_HOST was node.
- After this change, the rendered popup footer is pi and feedback targets the Pi pane.

## Verification

- cargo test --workspace
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- Live Herdr annotate.last popup readback against Pi 0.84.4