### PR TITLE
fix(hosts): read opencode 2 sessions and messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ directory in this repo is the development manifest; users should install Herdr A
 
 `plannotator-tui last` finds the transcript of the agent that launched your shell and shows a
 picker of its recent replies. Hosts: Claude Code, Codex, pi, Oh My Pi, GitHub Copilot CLI,
-Droid, Hermes CLI, OpenCode. `--host`, `--pid`, `--session <transcript>` (format sniffed when
+Droid, Hermes CLI, OpenCode (1 and 2). `--host`, `--pid`, `--session <transcript>` (format sniffed when
 no host is named) and `--session-id <id>` (Hermes, OpenCode) override detection; `--stdin`
 reads a document;
 `--print` writes the newest reply to stdout and always exits 0 (for hooks and scripts).

--- a/crates/plannotator-tui-hosts/src/opencode.rs
+++ b/crates/plannotator-tui-hosts/src/opencode.rs
@@ -10,6 +10,14 @@
 //!   `parent_id`; archived sessions carry `time_archived`;
 //! - a message's text is its `part` rows of type `text`, in id order; parts flagged
 //!   `synthetic` or `ignored` are injected context, not something the user or model wrote.
+//!
+//! `OpenCode` 2 (the `opencode2` binary, `anomalyco/opencode` branch `beta`) shares the data
+//! directory and, on the standard channels, the same `opencode.db`, but writes to new tables:
+//! `session_v2` (same columns this reader needs) and `session_message` (`type` column is the
+//! role, `seq` is the order, `data` holds the payload: `content[].type == "text"` for an
+//! assistant, `text` for a user). Other channels use `opencode-<channel>.db` next to it
+//! (`packages/cli/src/server-process.ts`). A v1 session and a v2 session can therefore both
+//! match one directory; the newest wins, whichever schema and file it lives in.
 
 use std::path::Path;
 
@@ -25,39 +33,113 @@ pub const DATA_DIR: &str = "opencode";
 
 const WHAT: &str = "OpenCode";
 
-/// The newest top-level, unarchived session started in `cwd`. When none was started exactly
-/// there, the newest one started in an ancestor of `cwd` (`OpenCode` records the directory it
-/// was launched from; the pane may have moved since).
-pub fn find_session(db: &Path, cwd: &Path) -> Result<String, HostError> {
+/// Which table family a session lives in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Schema {
+    /// `OpenCode` 1: `session`, `message`, `part`.
+    V1,
+    /// `OpenCode` 2: `session_v2`, `session_message`.
+    V2,
+}
+
+/// A session picked for a directory, with what is needed to compare picks across files.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Found {
+    pub id: String,
+    pub schema: Schema,
+    /// `time_updated`, Unix milliseconds.
+    pub updated: i64,
+}
+
+/// The newest top-level, unarchived session started in `cwd`, across both schemas. When none
+/// was started exactly there, the newest one started in an ancestor of `cwd` (`OpenCode`
+/// records the directory it was launched from; the pane may have moved since).
+pub fn find_session(db: &Path, cwd: &Path) -> Result<Found, HostError> {
     let connection = open_read_only(db, WHAT)?;
-    let mut statement = connection
-        .prepare(
-            "SELECT id, directory FROM session \
-             WHERE parent_id IS NULL AND time_archived IS NULL \
-             ORDER BY time_updated DESC",
-        )
-        .map_err(|e| sql_error(WHAT, &e))?;
-    let rows = statement
-        .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))
-        .map_err(|e| sql_error(WHAT, &e))?;
     let cwd = normalize(&cwd.to_string_lossy());
-    let mut ancestor: Option<String> = None;
-    for row in rows {
-        let (id, directory) = row.map_err(|e| sql_error(WHAT, &e))?;
-        let directory = normalize(&directory);
-        if directory == cwd {
-            return Ok(id);
+    let mut exact: Option<Found> = None;
+    let mut ancestor: Option<Found> = None;
+    for (schema, table) in [(Schema::V2, "session_v2"), (Schema::V1, "session")] {
+        if !has_table(&connection, table)? {
+            continue;
         }
-        if ancestor.is_none() && is_ancestor(&directory, &cwd) {
-            ancestor = Some(id);
+        let mut statement = connection
+            .prepare(&format!(
+                "SELECT id, directory, time_updated FROM {table} \
+                 WHERE parent_id IS NULL AND time_archived IS NULL"
+            ))
+            .map_err(|e| sql_error(WHAT, &e))?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?))
+            })
+            .map_err(|e| sql_error(WHAT, &e))?;
+        for row in rows {
+            let (id, directory, updated) = row.map_err(|e| sql_error(WHAT, &e))?;
+            let directory = normalize(&directory);
+            let found = Found { id, schema, updated };
+            if directory == cwd {
+                newer(&mut exact, found);
+            } else if is_ancestor(&directory, &cwd) {
+                newer(&mut ancestor, found);
+            }
         }
     }
-    ancestor
+    exact
+        .or(ancestor)
         .ok_or_else(|| HostError::NoTranscript(format!("no OpenCode session for {cwd} in {}", db.display())))
 }
 
+/// Which schema holds `session_id`, for sessions addressed by id rather than found by cwd.
+pub fn schema_of(db: &Path, session_id: &str) -> Result<Schema, HostError> {
+    let connection = open_read_only(db, WHAT)?;
+    for (schema, table) in [(Schema::V2, "session_v2"), (Schema::V1, "session")] {
+        if !has_table(&connection, table)? {
+            continue;
+        }
+        let count: i64 = connection
+            .query_row(&format!("SELECT count(*) FROM {table} WHERE id = ?1"), params![session_id], |r| {
+                r.get(0)
+            })
+            .map_err(|e| sql_error(WHAT, &e))?;
+        if count > 0 {
+            return Ok(schema);
+        }
+    }
+    Err(HostError::NoMessages(format!("no OpenCode session {session_id} in {}", db.display())))
+}
+
+fn newer(slot: &mut Option<Found>, candidate: Found) {
+    if slot.as_ref().is_none_or(|current| candidate.updated > current.updated) {
+        *slot = Some(candidate);
+    }
+}
+
+fn has_table(connection: &rusqlite::Connection, name: &str) -> Result<bool, HostError> {
+    connection
+        .query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            params![name],
+            |row| row.get::<_, i64>(0),
+        )
+        .map(|n| n > 0)
+        .map_err(|e| sql_error(WHAT, &e))
+}
+
 /// The newest `n` user and assistant messages of `session_id` that carry text, newest first.
-pub fn messages_for_session(db: &Path, session_id: &str, n: usize) -> Result<Vec<Message>, HostError> {
+pub fn messages_for_session(
+    db: &Path,
+    session_id: &str,
+    schema: Schema,
+    n: usize,
+) -> Result<Vec<Message>, HostError> {
+    match schema {
+        Schema::V1 => messages_v1(db, session_id, n),
+        Schema::V2 => messages_v2(db, session_id, n),
+    }
+}
+
+fn messages_v1(db: &Path, session_id: &str, n: usize) -> Result<Vec<Message>, HostError> {
     let connection = open_read_only(db, WHAT)?;
     // One indexed pass: every text part of the session, grouped by message, newest message
     // first and parts in creation order within it.
@@ -103,6 +185,71 @@ pub fn messages_for_session(db: &Path, session_id: &str, n: usize) -> Result<Vec
     }
     if messages.len() < n {
         flush(&mut current, &mut messages);
+    }
+    if messages.is_empty() {
+        return Err(HostError::NoMessages(format!(
+            "no messages for OpenCode session {session_id} in {}",
+            db.display()
+        )));
+    }
+    Ok(messages)
+}
+
+/// `OpenCode` 2: one `session_message` row per message; the payload carries the text directly.
+fn messages_v2(db: &Path, session_id: &str, n: usize) -> Result<Vec<Message>, HostError> {
+    let connection = open_read_only(db, WHAT)?;
+    let mut statement = connection
+        .prepare(
+            "SELECT id, type, data, time_created FROM session_message \
+             WHERE session_id = ?1 AND type IN ('user', 'assistant') \
+             ORDER BY seq DESC",
+        )
+        .map_err(|e| sql_error(WHAT, &e))?;
+    let rows = statement
+        .query_map(params![session_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+            ))
+        })
+        .map_err(|e| sql_error(WHAT, &e))?;
+    let mut messages = Vec::new();
+    for row in rows {
+        if messages.len() >= n {
+            break;
+        }
+        let (id, kind, data, created) = row.map_err(|e| sql_error(WHAT, &e))?;
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(&data) else { continue };
+        let (role, text) = match kind.as_str() {
+            "assistant" => {
+                let parts: Vec<&str> = json
+                    .get("content")
+                    .and_then(serde_json::Value::as_array)
+                    .map(|items| {
+                        items
+                            .iter()
+                            .filter(|item| item.get("type").and_then(|t| t.as_str()) == Some("text"))
+                            .filter_map(|item| item.get("text").and_then(|t| t.as_str()))
+                            .filter(|t| !t.trim().is_empty())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                (Role::Assistant, parts.join("\n\n"))
+            }
+            "user" => (Role::Human, json.get("text").and_then(|t| t.as_str()).unwrap_or_default().to_owned()),
+            _ => continue,
+        };
+        if text.trim().is_empty() {
+            continue;
+        }
+        let at = json
+            .pointer("/time/created")
+            .and_then(serde_json::Value::as_u64)
+            .or_else(|| u64::try_from(created).ok())
+            .map(crate::time::iso_from_unix_ms);
+        messages.push(Message { id, role, text, at });
     }
     if messages.is_empty() {
         return Err(HostError::NoMessages(format!(

--- a/crates/plannotator-tui-hosts/tests/opencode.rs
+++ b/crates/plannotator-tui-hosts/tests/opencode.rs
@@ -4,6 +4,7 @@
 
 use std::path::{Path, PathBuf};
 
+use plannotator_tui_hosts::opencode::{Found, Schema};
 use plannotator_tui_hosts::{HostError, Role, opencode};
 use rusqlite::{Connection, params};
 
@@ -18,6 +19,124 @@ CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEX
 CREATE INDEX message_session_time_created_id_idx ON message (session_id, time_created, id);
 CREATE INDEX part_message_id_id_idx ON part (message_id, id);
 ";
+
+/// The `OpenCode` 2 tables (`packages/core/src/session/sql.ts` on the `beta` branch), the columns
+/// this reader touches.
+const SCHEMA_V2: &str = "
+CREATE TABLE session_v2 (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, workspace_id TEXT, parent_id TEXT,
+    slug TEXT NOT NULL, directory TEXT NOT NULL, title TEXT, version TEXT NOT NULL,
+    time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, time_archived INTEGER);
+CREATE TABLE session_message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, type TEXT NOT NULL, seq INTEGER NOT NULL,
+    time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL);
+CREATE UNIQUE INDEX session_message_session_seq_idx ON session_message (session_id, seq);
+";
+
+fn session_v2(
+    c: &Connection,
+    id: &str,
+    dir: &str,
+    parent: Option<&str>,
+    updated: i64,
+    archived: Option<i64>,
+) {
+    c.execute(
+        "INSERT INTO session_v2 (id, project_id, parent_id, slug, directory, version, time_created, time_updated, time_archived) \
+         VALUES (?1, 'p', ?2, ?1, ?3, '0.0.0-beta', ?4, ?4, ?5)",
+        params![id, parent, dir, updated, archived],
+    )
+    .expect("session_v2");
+}
+
+fn message_v2(c: &Connection, id: &str, session: &str, seq: i64, kind: &str, data: &str) {
+    c.execute(
+        "INSERT INTO session_message (id, session_id, type, seq, time_created, time_updated, data) VALUES (?1, ?2, ?3, ?4, ?5, ?5, ?6)",
+        params![id, session, kind, seq, seq * 10, data],
+    )
+    .expect("session_message");
+}
+
+/// A database `OpenCode` 2 has written to: the v1 tables with an older session for `/work/app`
+/// (as after the v1 migration) plus the v2 tables with a newer session for the same directory.
+fn populate_v2(db: &Path) -> Connection {
+    let c = populate(db);
+    c.execute_batch(SCHEMA_V2).expect("schema v2");
+    session_v2(&c, "ses2_new", "/work/app", None, 5000, None);
+    session_v2(&c, "ses2_child", "/work/app", Some("ses2_new"), 9000, None);
+    session_v2(&c, "ses2_gone", "/work/app", None, 9500, Some(9500));
+    message_v2(
+        &c,
+        "msg2_1",
+        "ses2_new",
+        1,
+        "user",
+        r#"{"text":"reply with exactly OPENCODE2_V2_SESSION_SELECTED","files":[],"agents":[],"skills":[],"time":{"created":50000}}"#,
+    );
+    message_v2(
+        &c,
+        "msg2_2",
+        "ses2_new",
+        2,
+        "synthetic",
+        r#"{"text":"<system-reminder>injected</system-reminder>","time":{"created":50001}}"#,
+    );
+    message_v2(
+        &c,
+        "msg2_3",
+        "ses2_new",
+        3,
+        "assistant",
+        r#"{"agent":"build","model":{"providerID":"x","id":"y"},"content":[{"type":"reasoning","text":"thinking"},{"type":"text","text":"OPENCODE2_V2_SESSION_SELECTED"},{"type":"tool","id":"t","name":"read","state":{"status":"completed","input":{},"content":[]},"time":{"created":50002}},{"type":"text","text":"Done."}],"time":{"created":50002,"completed":50003}}"#,
+    );
+    message_v2(
+        &c,
+        "msg2_4",
+        "ses2_new",
+        4,
+        "assistant",
+        r#"{"agent":"build","model":{"providerID":"x","id":"y"},"content":[{"type":"reasoning","text":"aborted"}],"time":{"created":50004}}"#,
+    );
+    message_v2(&c, "msg2_5", "ses2_new", 5, "agent-switched", r#"{"agent":"plan","time":{"created":50005}}"#);
+    c
+}
+
+#[test]
+fn an_opencode2_session_in_the_same_database_wins_when_it_is_newer() {
+    let dir = temp_dir("v2");
+    let db = dir.join("opencode.db");
+    let writer = populate_v2(&db);
+    let found = opencode::find_session(&db, Path::new("/work/app")).expect("found");
+    assert_eq!(found, Found { id: "ses2_new".to_owned(), schema: Schema::V2, updated: 5000 });
+    // The v1 session is still the answer for a directory only v1 knows.
+    assert_eq!(opencode::find_session(&db, Path::new("/work/other")).expect("v1 only").schema, Schema::V1);
+    assert_eq!(opencode::schema_of(&db, "ses2_new").expect("v2"), Schema::V2);
+    assert_eq!(opencode::schema_of(&db, "ses_main").expect("v1"), Schema::V1);
+    assert!(matches!(opencode::schema_of(&db, "ses_nope"), Err(HostError::NoMessages(_))));
+
+    let messages = opencode::messages_for_session(&db, "ses2_new", Schema::V2, 25).expect("messages");
+    let texts: Vec<&str> = messages.iter().map(|m| m.text.as_str()).collect();
+    assert_eq!(
+        texts,
+        ["OPENCODE2_V2_SESSION_SELECTED\n\nDone.", "reply with exactly OPENCODE2_V2_SESSION_SELECTED"]
+    );
+    assert_eq!(messages[0].role, Role::Assistant);
+    assert_eq!(messages[0].id, "msg2_3");
+    assert_eq!(messages[0].at.as_deref(), Some("1970-01-01T00:00:50.002Z"));
+    assert_eq!(messages[1].role, Role::Human);
+    // n counts messages with text: the reasoning-only turn and the switch rows take no slot.
+    assert_eq!(opencode::messages_for_session(&db, "ses2_new", Schema::V2, 1).expect("one").len(), 1);
+    drop(writer);
+    std::fs::remove_dir_all(&dir).expect("cleanup");
+}
+
+#[test]
+fn a_database_without_the_v2_tables_still_reads_v1() {
+    let dir = temp_dir("v1only");
+    let db = dir.join("opencode.db");
+    let writer = populate(&db);
+    assert_eq!(opencode::find_session(&db, Path::new("/work/app")).expect("v1").schema, Schema::V1);
+    drop(writer);
+    std::fs::remove_dir_all(&dir).expect("cleanup");
+}
 
 fn temp_dir(tag: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!("plannotator-tui-opencode-{tag}-{}", std::process::id()));
@@ -100,12 +219,12 @@ fn newest_session_for_the_directory_skips_children_and_archived_ones() {
     let dir = temp_dir("find");
     let db = dir.join("opencode.db");
     let writer = populate(&db);
-    assert_eq!(opencode::find_session(&db, Path::new("/work/app")).expect("exact"), "ses_main");
-    assert_eq!(opencode::find_session(&db, Path::new("/work/app/")).expect("trailing slash"), "ses_main");
+    assert_eq!(opencode::find_session(&db, Path::new("/work/app")).expect("exact").id, "ses_main");
+    assert_eq!(opencode::find_session(&db, Path::new("/work/app/")).expect("trailing slash").id, "ses_main");
     // Started in an ancestor: the newest session there, never a sibling project.
-    assert_eq!(opencode::find_session(&db, Path::new("/work/app/src/deep")).expect("nested"), "ses_main");
-    assert_eq!(opencode::find_session(&db, Path::new("/work/tools")).expect("root"), "ses_root");
-    assert_eq!(opencode::find_session(&db, Path::new("/work/other")).expect("other"), "ses_other");
+    assert_eq!(opencode::find_session(&db, Path::new("/work/app/src/deep")).expect("nested").id, "ses_main");
+    assert_eq!(opencode::find_session(&db, Path::new("/work/tools")).expect("root").id, "ses_root");
+    assert_eq!(opencode::find_session(&db, Path::new("/work/other")).expect("other").id, "ses_other");
     match opencode::find_session(&db, Path::new("/elsewhere")) {
         Err(HostError::NoTranscript(msg)) => assert!(msg.contains("/elsewhere"), "{msg}"),
         other => panic!("expected NoTranscript, got {other:?}"),
@@ -119,7 +238,7 @@ fn text_parts_join_in_order_and_injected_or_empty_ones_are_skipped() {
     let dir = temp_dir("read");
     let db = dir.join("opencode.db");
     let writer = populate(&db);
-    let messages = opencode::messages_for_session(&db, "ses_main", 25).expect("messages");
+    let messages = opencode::messages_for_session(&db, "ses_main", Schema::V1, 25).expect("messages");
     let texts: Vec<&str> = messages.iter().map(|m| m.text.as_str()).collect();
     assert_eq!(
         texts,
@@ -135,9 +254,9 @@ fn text_parts_join_in_order_and_injected_or_empty_ones_are_skipped() {
     assert_eq!(messages[0].at.as_deref(), Some("1970-01-01T00:00:00.050Z"));
     assert_eq!(messages[1].role, Role::Human);
     // n counts messages with text; the aborted assistant turn does not consume a slot.
-    let two = opencode::messages_for_session(&db, "ses_main", 2).expect("two");
+    let two = opencode::messages_for_session(&db, "ses_main", Schema::V1, 2).expect("two");
     assert_eq!(two.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(), ["msg_5", "msg_4"]);
-    match opencode::messages_for_session(&db, "ses_empty", 25) {
+    match opencode::messages_for_session(&db, "ses_empty", Schema::V1, 25) {
         Err(HostError::NoMessages(msg)) => assert!(msg.contains("ses_empty"), "{msg}"),
         other => panic!("expected NoMessages, got {other:?}"),
     }

--- a/crates/plannotator-tui/src/last/locate.rs
+++ b/crates/plannotator-tui/src/last/locate.rs
@@ -78,12 +78,30 @@ pub(crate) fn locate(options: &LastOptions) -> Result<Located> {
             (db, messages)
         }
         (Host::OpenCode, _) => {
-            let db = opencode_db();
-            let id = match options.session_id.as_deref().filter(|s| !s.trim().is_empty()) {
-                Some(id) => id.to_owned(),
-                None => opencode::find_session(&db, &agent_cwd()?)?,
+            let databases = opencode_databases();
+            let named = options.session_id.as_deref().filter(|s| !s.trim().is_empty());
+            let (db, id, schema) = if let Some(id) = named {
+                let (db, schema) = databases
+                    .iter()
+                    .find_map(|db| opencode::schema_of(db, id).ok().map(|schema| (db.clone(), schema)))
+                    .with_context(|| format!("no OpenCode session {id} in {}", describe(&databases)))?;
+                (db, id.to_owned(), schema)
+            } else {
+                let cwd = agent_cwd()?;
+                let mut best: Option<(PathBuf, opencode::Found)> = None;
+                for db in &databases {
+                    if let Ok(found) = opencode::find_session(db, &cwd)
+                        && best.as_ref().is_none_or(|(_, b)| found.updated > b.updated)
+                    {
+                        best = Some((db.clone(), found));
+                    }
+                }
+                let (db, found) = best.with_context(|| {
+                    format!("no OpenCode session for {} in {}", cwd.display(), describe(&databases))
+                })?;
+                (db, found.id, found.schema)
             };
-            let messages = opencode::messages_for_session(&db, &id, pick)?;
+            let messages = opencode::messages_for_session(&db, &id, schema, pick)?;
             (db, messages)
         }
     };
@@ -174,17 +192,40 @@ fn hermes_home() -> PathBuf {
     home().join(".hermes")
 }
 
-/// `OpenCode`'s database: `$OPENCODE_DB`, else `<xdg data>/opencode/opencode.db` where the
-/// xdg data dir is `$XDG_DATA_HOME` or `~/.local/share` (opencode `packages/core/src/global.ts`
-/// uses `xdg-basedir`, which applies the same rule on every platform).
-fn opencode_db() -> PathBuf {
+/// `OpenCode`'s databases: `$OPENCODE_DB` alone when set; else every `opencode*.db` in
+/// `<xdg data>/opencode` (`opencode.db` for the standard channels, `opencode-<channel>.db`
+/// for others), where the xdg data dir is `$XDG_DATA_HOME` or `~/.local/share`
+/// (`packages/util/src/global-roots.ts`, `packages/cli/src/server-process.ts`).
+fn opencode_databases() -> Vec<PathBuf> {
     if let Some(db) = std::env::var_os("OPENCODE_DB").filter(|v| !v.is_empty()) {
-        return PathBuf::from(db);
+        return vec![PathBuf::from(db)];
     }
     let data = std::env::var_os("XDG_DATA_HOME")
         .filter(|v| !v.is_empty())
-        .map_or_else(|| home().join(".local").join("share"), PathBuf::from);
-    data.join(opencode::DATA_DIR).join(opencode::DB_FILE)
+        .map_or_else(|| home().join(".local").join("share"), PathBuf::from)
+        .join(opencode::DATA_DIR);
+    let mut found: Vec<PathBuf> = std::fs::read_dir(&data)
+        .map(|entries| {
+            entries
+                .filter_map(Result::ok)
+                .map(|e| e.path())
+                .filter(|p| {
+                    p.file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|n| n.starts_with("opencode") && n.to_ascii_lowercase().ends_with(".db"))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    found.sort();
+    if found.is_empty() {
+        found.push(data.join(opencode::DB_FILE));
+    }
+    found
+}
+
+fn describe(databases: &[PathBuf]) -> String {
+    databases.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ")
 }
 
 fn home() -> PathBuf {

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -347,3 +347,19 @@ database is opened read-only exactly as for Hermes (shared opener, `mode=ro` the
 `immutable=1`); one query joins `message` and `part` newest-message-first. `OPENCODE=1` in the
 environment now selects this host instead of reporting it unsupported. Verified live against
 opencode 1.18.23 (`~/.local/share/opencode/opencode.db`, 45 MB, WAL) on 2026-08-29.
+
+**OpenCode 2** (2026-08-30, plannotator-tui#40). The `opencode2` binary (`anomalyco/opencode`,
+branch `beta`, `packages/cli`) keeps the same data directory and, on the standard channels
+(`latest`, `dev`, `beta`, `next`, `prod`), the same `opencode.db`, but writes to new tables:
+`session_v2` (the columns this reader uses are unchanged: `directory`, `parent_id`,
+`time_updated`, `time_archived`) and `session_message` (`type` is the role, `seq` the order,
+`data` the payload; an assistant's text is `content[].type == "text"`, a user's is `text`;
+`synthetic`, `system`, `skill`, `shell`, `compaction` and the `*-switched` rows are not
+rendered). There is no `part` table. Other channels use `opencode-<channel>.db` beside it
+(`packages/cli/src/server-process.ts`). After the v1 migration both table families hold data,
+so the reader now considers every `opencode*.db` in the data dir and both schemas, and picks
+the newest top-level unarchived session for the cwd across all of them; a `--session-id` is
+looked up in whichever table holds it. Verified against the `beta` source
+(`packages/core/src/session/sql.ts`, `packages/schema/src/session-message.ts`,
+`packages/util/src/global-roots.ts`) and a mixed-schema fixture reproducing the report.
+


### PR DESCRIPTION
Fixes #40.

OpenCode 2 (`opencode2`, `anomalyco/opencode` branch `beta`) shares `~/.local/share/opencode` and, on the standard channels, `opencode.db` with OpenCode 1, but writes to new tables: `session_v2` and `session_message` (no `part` table; assistant text is `content[].type == "text"`, user text is `text`, `seq` orders rows). Other channels use `opencode-<channel>.db`. The reader only knew the v1 tables, so for a directory with both it returned the older v1 session.

Now: every `opencode*.db` in the data dir is considered, both schemas are read, and the newest top-level unarchived session for the cwd wins across all of them; `--session-id` resolves in whichever table holds it. Source-verified on the `beta` branch; tests add the v2 tables to the fixture and reproduce the report (older v1 session, newer v2 session, v2 wins with the expected text); the real CLI prints `OPENCODE2_V2_SESSION_SELECTED` against that fixture.

refs #40

https://claude.ai/code/session_01L232F8ev8RX6Jwd7PepsUz