### PR TITLE
release: 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,7 @@ checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plannotator-tui"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "plannotator-tui-hosts",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "plannotator-tui-hosts"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "rusqlite",
  "serde_json",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "plannotator-tui-schema"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "jsonschema",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/plannotator-tui-schema", "crates/plannotator-tui-hosts", "crates/plannotator-tui"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/crates/plannotator-tui/Cargo.toml
+++ b/crates/plannotator-tui/Cargo.toml
@@ -14,8 +14,8 @@ name = "plannotator-tui"
 path = "src/main.rs"
 
 [dependencies]
-plannotator-tui-schema = { path = "../plannotator-tui-schema", version = "0.4.0" }
-plannotator-tui-hosts = { path = "../plannotator-tui-hosts", version = "0.4.0" }
+plannotator-tui-schema = { path = "../plannotator-tui-schema", version = "0.4.1" }
+plannotator-tui-hosts = { path = "../plannotator-tui-hosts", version = "0.4.1" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Patch release.

- fix(hosts): read OpenCode 2 sessions and messages (#42, refs #40, reported by @r4ravi2008)
- fix(herdr): trust Herdr's reported agent host over the process name; pi installed via npm (#41, by @r4ravi2008)

Tag `v0.4.1` follows on the merge commit.

https://claude.ai/code/session_01L232F8ev8RX6Jwd7PepsUz