### PR TITLE
release: 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,7 @@ checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plannotator-tui"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "plannotator-tui-hosts",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "plannotator-tui-hosts"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "rusqlite",
  "serde_json",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "plannotator-tui-schema"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "jsonschema",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/plannotator-tui-schema", "crates/plannotator-tui-hosts", "crates/plannotator-tui"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/crates/plannotator-tui/Cargo.toml
+++ b/crates/plannotator-tui/Cargo.toml
@@ -14,8 +14,8 @@ name = "plannotator-tui"
 path = "src/main.rs"
 
 [dependencies]
-plannotator-tui-schema = { path = "../plannotator-tui-schema", version = "0.4.1" }
-plannotator-tui-hosts = { path = "../plannotator-tui-hosts", version = "0.4.1" }
+plannotator-tui-schema = { path = "../plannotator-tui-schema", version = "0.5.0" }
+plannotator-tui-hosts = { path = "../plannotator-tui-hosts", version = "0.5.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Feature release.

- feat: multi-line comments (Enter saves; Shift+Enter where the terminal supports it, Alt+Enter/Ctrl+J everywhere; bracketed paste lands verbatim) (#44)
- feat: double-click a block to open the annotation toolbar (#44)
- feat(tree): lazy folder tree; instant open in any folder; records remember their document for folder-wide sends (#44)

Tag `v0.5.0` follows on the merge commit.

https://claude.ai/code/session_01L232F8ev8RX6Jwd7PepsUz