### PR TITLE
exact session resolution + Windows proof

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rs text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
-# Pull-request gate: fmt + clippy + tests on Ubuntu, and clippy alone on Windows (cfg(windows)
-# code is invisible to clippy elsewhere). Both jobs run in parallel and are cancelled when the
-# PR is updated. Full cross-platform tests and release builds run after merge.
+# Pull-request gate: the full suite on Ubuntu and Windows. Both jobs run in parallel and are
+# cancelled when the PR is updated.
 name: ci
 
 on:
@@ -30,11 +29,15 @@ jobs:
 
   check-windows:
     runs-on: windows-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --all --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo test --workspace --all-targets
+      - run: cargo build --release -p plannotator-tui
+      - run: '& .\target\release\plannotator-tui.exe --version'

--- a/crates/plannotator-tui-hosts/src/claude/ladder.rs
+++ b/crates/plannotator-tui-hosts/src/claude/ladder.rs
@@ -76,7 +76,7 @@ fn transcript_for_session(
 }
 
 /// The project dir for `cwd`, exact name first, then case-insensitively (Windows lowercases).
-fn project_dir(projects_dir: &Path, cwd: &Path) -> Option<PathBuf> {
+pub(super) fn project_dir(projects_dir: &Path, cwd: &Path) -> Option<PathBuf> {
     let slug = project_slug(cwd);
     let exact = projects_dir.join(&slug);
     if exact.is_dir() {

--- a/crates/plannotator-tui-hosts/src/claude/mod.rs
+++ b/crates/plannotator-tui-hosts/src/claude/mod.rs
@@ -12,6 +12,30 @@ use crate::SessionMeta;
 pub use ladder::find_transcript;
 pub use messages::{parse_messages, parse_messages_file_order};
 
+/// Find `<projects>/*/<id>.jsonl`, preferring the current cwd's project bucket.
+pub fn find_transcript_by_id(
+    projects_dir: &Path,
+    cwd: &Path,
+    session_id: &str,
+) -> Result<Option<PathBuf>, crate::HostError> {
+    let id = crate::validate_session_id(session_id)?;
+    let preferred = ladder::project_dir(projects_dir, cwd);
+    if let Some(path) = preferred.as_ref().map(|dir| dir.join(format!("{id}.jsonl")))
+        && path.is_file()
+    {
+        return Ok(Some(path));
+    }
+    let mut project_dirs: Vec<PathBuf> = std::fs::read_dir(projects_dir)
+        .map(|entries| entries.flatten().map(|entry| entry.path()).filter(|path| path.is_dir()).collect())
+        .unwrap_or_default();
+    project_dirs.sort();
+    Ok(project_dirs
+        .into_iter()
+        .filter(|dir| preferred.as_ref() != Some(dir))
+        .map(|dir| dir.join(format!("{id}.jsonl")))
+        .find(|path| path.is_file()))
+}
+
 /// Parse one `sessions/<pid>.json`. Fields beyond the four we use are ignored.
 pub fn parse_session_meta(json: &str) -> Option<SessionMeta> {
     let value: serde_json::Value = serde_json::from_str(json).ok()?;

--- a/crates/plannotator-tui-hosts/src/codex.rs
+++ b/crates/plannotator-tui-hosts/src/codex.rs
@@ -22,6 +22,12 @@ pub fn find_transcripts(codex_home: &Path, thread_id: Option<&str>) -> Vec<PathB
     rollouts.into_iter().filter(|p| thread_of(p).as_deref() == Some(thread.as_str())).collect()
 }
 
+/// The transcript files for one validated exact thread id, oldest first.
+pub fn find_transcripts_by_id(codex_home: &Path, session_id: &str) -> Result<Vec<PathBuf>, crate::HostError> {
+    let id = crate::validate_session_id(session_id)?;
+    Ok(find_transcripts(codex_home, Some(id)))
+}
+
 fn all_rollouts(dir: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let Ok(entries) = std::fs::read_dir(dir) else { return out };

--- a/crates/plannotator-tui-hosts/src/copilot.rs
+++ b/crates/plannotator-tui-hosts/src/copilot.rs
@@ -15,6 +15,16 @@ use crate::{Message, Role};
 
 const MAX_ANCESTOR_HOPS: usize = 8;
 
+/// Find `$COPILOT_HOME/session-state/<id>` when it contains an events transcript.
+pub fn find_session_by_id(
+    copilot_home: &Path,
+    session_id: &str,
+) -> Result<Option<PathBuf>, crate::HostError> {
+    let id = crate::validate_session_id(session_id)?;
+    let dir = copilot_home.join("session-state").join(id);
+    Ok(dir.join("events.jsonl").is_file().then_some(dir))
+}
+
 /// The session directory for the Copilot process we were launched from.
 ///
 /// 1. Walk `start_pid` and up to eight ancestors; the first pid that owns an

--- a/crates/plannotator-tui-hosts/src/droid.rs
+++ b/crates/plannotator-tui-hosts/src/droid.rs
@@ -13,6 +13,31 @@ use std::time::SystemTime;
 use crate::Message;
 use crate::claude::{parse_messages_file_order, project_slug};
 
+/// Find `$FACTORY_CONFIG_DIR/sessions/*/<id>.jsonl`, preferring the current cwd's slug.
+pub fn find_transcript_by_id(
+    factory_dir: &Path,
+    cwd: &Path,
+    session_id: &str,
+) -> Result<Option<PathBuf>, crate::HostError> {
+    let id = crate::validate_session_id(session_id)?;
+    let sessions_dir = factory_dir.join("sessions");
+    let preferred = slug_dir(&sessions_dir, cwd);
+    if let Some(path) = preferred.as_ref().map(|dir| dir.join(format!("{id}.jsonl")))
+        && path.is_file()
+    {
+        return Ok(Some(path));
+    }
+    let mut slug_dirs: Vec<PathBuf> = std::fs::read_dir(&sessions_dir)
+        .map(|entries| entries.flatten().map(|entry| entry.path()).filter(|path| path.is_dir()).collect())
+        .unwrap_or_default();
+    slug_dirs.sort();
+    Ok(slug_dirs
+        .into_iter()
+        .filter(|dir| preferred.as_ref() != Some(dir))
+        .map(|dir| dir.join(format!("{id}.jsonl")))
+        .find(|path| path.is_file()))
+}
+
 /// The current session log for `cwd`, per the rule above. `None` when no slug directory
 /// on the way up holds a transcript.
 pub fn find_transcript(factory_dir: &Path, cwd: &Path) -> Option<PathBuf> {

--- a/crates/plannotator-tui-hosts/src/hermes.rs
+++ b/crates/plannotator-tui-hosts/src/hermes.rs
@@ -21,6 +21,7 @@ const WHAT: &str = "Hermes";
 /// live WAL; when the shared-memory index cannot be opened, the read falls back to
 /// `immutable=1`, which reads the main file only and may lag an active writer.
 pub fn messages_for_session(db: &Path, session_id: &str, n: usize) -> Result<Vec<Message>, HostError> {
+    crate::validate_session_id(session_id)?;
     let connection = open_read_only(db, WHAT)?;
     let mut statement = connection
         .prepare(

--- a/crates/plannotator-tui-hosts/src/lib.rs
+++ b/crates/plannotator-tui-hosts/src/lib.rs
@@ -124,17 +124,29 @@ pub enum HostError {
     NoMessages(String),
     /// A host was recognised from the environment but is not supported yet.
     Unsupported(String),
+    /// An exact session id is not one safe path component.
+    InvalidSessionId(String),
     Io(std::io::Error),
 }
 
 impl std::fmt::Display for HostError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::NoTranscript(msg) | Self::NoMessages(msg) => f.write_str(msg),
+            Self::NoTranscript(msg) | Self::NoMessages(msg) | Self::InvalidSessionId(msg) => f.write_str(msg),
             Self::Unsupported(host) => write!(f, "{host} is not supported yet"),
             Self::Io(err) => write!(f, "{err}"),
         }
     }
+}
+
+/// Reject an exact session id before a resolver touches the filesystem or a database.
+pub fn validate_session_id(id: &str) -> Result<&str, HostError> {
+    if id.trim().is_empty() || id.contains(['/', '\\', '\0']) || id.contains("..") {
+        return Err(HostError::InvalidSessionId(format!(
+            "invalid session id {id:?}: expected one non-empty path component"
+        )));
+    }
+    Ok(id)
 }
 
 impl std::error::Error for HostError {}

--- a/crates/plannotator-tui-hosts/src/omp.rs
+++ b/crates/plannotator-tui-hosts/src/omp.rs
@@ -10,6 +10,54 @@ use crate::{Message, pi};
 /// The agent directory relative to `$HOME`.
 pub const DEFAULT_AGENT_DIR: &str = ".omp/agent";
 
+/// The exact OMP session id, preferring OMP's current home/temp/absolute cwd bucket.
+pub fn find_transcript_by_id(
+    sessions_dir: &Path,
+    cwd: &Path,
+    home: &Path,
+    temp: &Path,
+    session_id: &str,
+) -> Result<Option<PathBuf>, crate::HostError> {
+    let preferred = sessions_dir.join(encoded_dir(cwd, home, temp));
+    pi::find_transcript_by_id_in(sessions_dir, &[preferred], session_id)
+}
+
+fn encoded_dir(cwd: &Path, home: &Path, temp: &Path) -> String {
+    let normalized = |path: &Path| path.to_string_lossy().replace('\\', "/").trim_end_matches('/').to_owned();
+    let cwd = normalized(cwd);
+    let relative = |root: &Path| {
+        let root = normalized(root);
+        let compare = |value: &str| {
+            if cfg!(windows) { value.to_ascii_lowercase() } else { value.to_owned() }
+        };
+        if compare(&cwd) == compare(&root) {
+            return Some(String::new());
+        }
+        let prefix = format!("{root}/");
+        compare(&cwd)
+            .strip_prefix(&compare(&prefix))
+            .and_then(|suffix| cwd.get(cwd.len().saturating_sub(suffix.len())..))
+            .map(str::to_owned)
+    };
+    let encode = |prefix: &str, relative: &str| {
+        let relative = relative.replace(['/', '\\', ':'], "-");
+        if relative.is_empty() {
+            prefix.to_owned()
+        } else if prefix.ends_with('-') {
+            format!("{prefix}{relative}")
+        } else {
+            format!("{prefix}-{relative}")
+        }
+    };
+    if let Some(relative) = relative(home) {
+        encode("-", &relative)
+    } else if let Some(relative) = relative(temp) {
+        encode("-tmp", &relative)
+    } else {
+        format!("--{}--", cwd.trim_start_matches('/').replace(['/', '\\', ':'], "-"))
+    }
+}
+
 /// The newest OMP session for `cwd`; pi's rules over OMP's root.
 pub fn find_transcript(sessions_dir: &Path, cwd: &Path) -> Option<PathBuf> {
     pi::find_transcript(sessions_dir, cwd)

--- a/crates/plannotator-tui-hosts/src/opencode.rs
+++ b/crates/plannotator-tui-hosts/src/opencode.rs
@@ -92,6 +92,7 @@ pub fn find_session(db: &Path, cwd: &Path) -> Result<Found, HostError> {
 
 /// Which schema holds `session_id`, for sessions addressed by id rather than found by cwd.
 pub fn schema_of(db: &Path, session_id: &str) -> Result<Schema, HostError> {
+    crate::validate_session_id(session_id)?;
     let connection = open_read_only(db, WHAT)?;
     for (schema, table) in [(Schema::V2, "session_v2"), (Schema::V1, "session")] {
         if !has_table(&connection, table)? {
@@ -133,6 +134,7 @@ pub fn messages_for_session(
     schema: Schema,
     n: usize,
 ) -> Result<Vec<Message>, HostError> {
+    crate::validate_session_id(session_id)?;
     match schema {
         Schema::V1 => messages_v1(db, session_id, n),
         Schema::V2 => messages_v2(db, session_id, n),

--- a/crates/plannotator-tui-hosts/src/pi.rs
+++ b/crates/plannotator-tui-hosts/src/pi.rs
@@ -12,6 +12,62 @@ use serde_json::Value;
 
 use crate::{Message, Role};
 
+/// Find `<timestamp>_<id>.jsonl`, preferring the current cwd's bucket, then searching
+/// recursively under the sessions root.
+pub fn find_transcript_by_id(
+    sessions_dir: &Path,
+    cwd: &Path,
+    session_id: &str,
+) -> Result<Option<PathBuf>, crate::HostError> {
+    find_transcript_by_id_in(sessions_dir, &[sessions_dir.join(encoded_dir(cwd))], session_id)
+}
+
+pub(crate) fn find_transcript_by_id_in(
+    sessions_dir: &Path,
+    preferred_dirs: &[PathBuf],
+    session_id: &str,
+) -> Result<Option<PathBuf>, crate::HostError> {
+    let id = crate::validate_session_id(session_id)?;
+    for dir in preferred_dirs {
+        if let Some(path) = matching_session_files(dir, id).into_iter().next() {
+            return Ok(Some(path));
+        }
+    }
+    let mut files = Vec::new();
+    collect_session_files(sessions_dir, id, &mut files);
+    files.sort();
+    Ok(files.into_iter().find(|path| !preferred_dirs.iter().any(|dir| path.parent() == Some(dir.as_path()))))
+}
+
+fn collect_session_files(dir: &Path, id: &str, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_session_files(&path, id, out);
+        } else if session_file_has_id(&path, id) {
+            out.push(path);
+        }
+    }
+}
+
+fn matching_session_files(dir: &Path, id: &str) -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = std::fs::read_dir(dir)
+        .map(|entries| {
+            entries.flatten().map(|entry| entry.path()).filter(|path| session_file_has_id(path, id)).collect()
+        })
+        .unwrap_or_default();
+    files.sort();
+    files
+}
+
+fn session_file_has_id(path: &Path, id: &str) -> bool {
+    path.is_file()
+        && path.file_name().and_then(|name| name.to_str()).is_some_and(|name| {
+            name.strip_suffix(".jsonl").is_some_and(|stem| stem.ends_with(&format!("_{id}")))
+        })
+}
+
 /// The directory pi writes a cwd's sessions into: two dashes, the cwd without its leading
 /// slash and with every slash, backslash and colon replaced by a dash, two dashes.
 pub fn encoded_dir(cwd: &Path) -> String {

--- a/crates/plannotator-tui-hosts/tests/exact_session.rs
+++ b/crates/plannotator-tui-hosts/tests/exact_session.rs
@@ -22,6 +22,13 @@ fn touch(path: &Path) {
     std::fs::write(path, "{}\n").expect("file");
 }
 
+fn assert_same_file(actual: Option<PathBuf>, expected: &Path) {
+    assert_eq!(
+        actual.expect("exact file").canonicalize().expect("actual canonical path"),
+        expected.canonicalize().expect("expected canonical path")
+    );
+}
+
 #[cfg(windows)]
 fn lookup_spelling(path: &Path) -> PathBuf {
     let mut text = path.to_string_lossy().replace('/', "\\");
@@ -51,9 +58,9 @@ fn exact_file_host_ids_prefer_the_current_windows_path_bucket() {
     touch(&claude_current);
     touch(&claude_other);
     touch(&claude_projects.join("newest-unrelated").join(format!("{OTHER_ID}.jsonl")));
-    assert_eq!(
+    assert_same_file(
         claude::find_transcript_by_id(&claude_projects, &lookup_cwd, ID).expect("claude"),
-        Some(claude_current)
+        &claude_current,
     );
     assert_eq!(claude::find_transcript_by_id(&claude_projects, &lookup_cwd, "missing").expect("miss"), None);
 
@@ -80,7 +87,7 @@ fn exact_file_host_ids_prefer_the_current_windows_path_bucket() {
     touch(&droid_current);
     touch(&droid_other);
     touch(&factory.join("sessions/newest-unrelated").join(format!("{OTHER_ID}.jsonl")));
-    assert_eq!(droid::find_transcript_by_id(&factory, &lookup_cwd, ID).expect("droid"), Some(droid_current));
+    assert_same_file(droid::find_transcript_by_id(&factory, &lookup_cwd, ID).expect("droid"), &droid_current);
     assert_eq!(droid::find_transcript_by_id(&factory, &lookup_cwd, "missing").expect("miss"), None);
 
     let pi_sessions = root.join("pi sessions");
@@ -90,7 +97,7 @@ fn exact_file_host_ids_prefer_the_current_windows_path_bucket() {
     touch(&pi_current);
     touch(&pi_other);
     touch(&pi_sessions.join("--newest--").join(format!("2026-09-01T10-00-00-000Z_{OTHER_ID}.jsonl")));
-    assert_eq!(pi::find_transcript_by_id(&pi_sessions, &lookup_cwd, ID).expect("pi"), Some(pi_current));
+    assert_same_file(pi::find_transcript_by_id(&pi_sessions, &lookup_cwd, ID).expect("pi"), &pi_current);
     assert_eq!(pi::find_transcript_by_id(&pi_sessions, &lookup_cwd, "missing").expect("miss"), None);
 
     let omp_sessions = root.join("omp sessions");
@@ -99,7 +106,7 @@ fn exact_file_host_ids_prefer_the_current_windows_path_bucket() {
     touch(&omp_current);
     touch(&omp_other);
     touch(&omp_sessions.join("--newest--").join(format!("2026-09-01T10-00-00-000Z_{OTHER_ID}.jsonl")));
-    assert_eq!(
+    assert_same_file(
         omp::find_transcript_by_id(
             &omp_sessions,
             &lookup_cwd,
@@ -108,7 +115,7 @@ fn exact_file_host_ids_prefer_the_current_windows_path_bucket() {
             ID,
         )
         .expect("omp"),
-        Some(omp_current)
+        &omp_current,
     );
     assert_eq!(
         omp::find_transcript_by_id(

--- a/crates/plannotator-tui-hosts/tests/exact_session.rs
+++ b/crates/plannotator-tui-hosts/tests/exact_session.rs
@@ -1,0 +1,222 @@
+//! Exact session ids select one named conversation before any heuristic discovery.
+
+#![allow(clippy::expect_used, reason = "tests assert by panicking")]
+
+use std::path::{Path, PathBuf};
+
+use plannotator_tui_hosts::{HostError, claude, codex, copilot, droid, hermes, omp, opencode, pi};
+use rusqlite::{Connection, params};
+
+const ID: &str = "11111111-1111-4111-8111-111111111111";
+const OTHER_ID: &str = "22222222-2222-4222-8222-222222222222";
+
+fn temp_dir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("plannotator exact {tag} ü-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    dir
+}
+
+fn touch(path: &Path) {
+    std::fs::create_dir_all(path.parent().expect("parent")).expect("parent");
+    std::fs::write(path, "{}\n").expect("file");
+}
+
+#[cfg(windows)]
+fn lookup_spelling(path: &Path) -> PathBuf {
+    let mut text = path.to_string_lossy().replace('/', "\\");
+    if text.as_bytes().get(1) == Some(&b':') {
+        let first = text.get(..1).unwrap_or_default().to_ascii_lowercase();
+        text.replace_range(..1, &first);
+    }
+    PathBuf::from(text)
+}
+
+#[cfg(not(windows))]
+fn lookup_spelling(path: &Path) -> PathBuf {
+    path.to_path_buf()
+}
+
+#[test]
+fn exact_file_host_ids_prefer_the_current_windows_path_bucket() {
+    let root = temp_dir("file hosts");
+    let home = root.join("home with spaces ü");
+    let cwd = home.join("work tree");
+    std::fs::create_dir_all(&cwd).expect("cwd");
+    let lookup_cwd = lookup_spelling(&cwd);
+
+    let claude_projects = root.join("claude root/projects");
+    let claude_current = claude_projects.join(claude::project_slug(&cwd)).join(format!("{ID}.jsonl"));
+    let claude_other = claude_projects.join("other-project").join(format!("{ID}.jsonl"));
+    touch(&claude_current);
+    touch(&claude_other);
+    touch(&claude_projects.join("newest-unrelated").join(format!("{OTHER_ID}.jsonl")));
+    assert_eq!(
+        claude::find_transcript_by_id(&claude_projects, &lookup_cwd, ID).expect("claude"),
+        Some(claude_current)
+    );
+    assert_eq!(claude::find_transcript_by_id(&claude_projects, &lookup_cwd, "missing").expect("miss"), None);
+
+    let codex_home = root.join("codex root");
+    let codex_file =
+        codex_home.join("sessions/2026/08/30").join(format!("rollout-2026-08-30T10-00-00-{ID}.jsonl"));
+    touch(&codex_file);
+    touch(
+        &codex_home.join("sessions/2026/08/31").join(format!("rollout-2026-08-31T10-00-00-{OTHER_ID}.jsonl")),
+    );
+    assert_eq!(codex::find_transcripts_by_id(&codex_home, ID).expect("codex"), vec![codex_file]);
+    assert!(codex::find_transcripts_by_id(&codex_home, "missing").expect("miss").is_empty());
+
+    let copilot_home = root.join("copilot root");
+    let copilot_session = copilot_home.join("session-state").join(ID);
+    touch(&copilot_session.join("events.jsonl"));
+    touch(&copilot_home.join("session-state").join(OTHER_ID).join("events.jsonl"));
+    assert_eq!(copilot::find_session_by_id(&copilot_home, ID).expect("copilot"), Some(copilot_session));
+    assert_eq!(copilot::find_session_by_id(&copilot_home, "missing").expect("miss"), None);
+
+    let factory = root.join("factory root");
+    let droid_current = factory.join("sessions").join(claude::project_slug(&cwd)).join(format!("{ID}.jsonl"));
+    let droid_other = factory.join("sessions/other-project").join(format!("{ID}.jsonl"));
+    touch(&droid_current);
+    touch(&droid_other);
+    touch(&factory.join("sessions/newest-unrelated").join(format!("{OTHER_ID}.jsonl")));
+    assert_eq!(droid::find_transcript_by_id(&factory, &lookup_cwd, ID).expect("droid"), Some(droid_current));
+    assert_eq!(droid::find_transcript_by_id(&factory, &lookup_cwd, "missing").expect("miss"), None);
+
+    let pi_sessions = root.join("pi sessions");
+    let pi_current =
+        pi_sessions.join(pi::encoded_dir(&cwd)).join(format!("2026-08-30T10-00-00-000Z_{ID}.jsonl"));
+    let pi_other = pi_sessions.join("--other--").join(format!("2026-08-31T10-00-00-000Z_{ID}.jsonl"));
+    touch(&pi_current);
+    touch(&pi_other);
+    touch(&pi_sessions.join("--newest--").join(format!("2026-09-01T10-00-00-000Z_{OTHER_ID}.jsonl")));
+    assert_eq!(pi::find_transcript_by_id(&pi_sessions, &lookup_cwd, ID).expect("pi"), Some(pi_current));
+    assert_eq!(pi::find_transcript_by_id(&pi_sessions, &lookup_cwd, "missing").expect("miss"), None);
+
+    let omp_sessions = root.join("omp sessions");
+    let omp_current = omp_sessions.join("-work tree").join(format!("2026-08-30T10-00-00-000Z_{ID}.jsonl"));
+    let omp_other = omp_sessions.join("--other--").join(format!("2026-08-31T10-00-00-000Z_{ID}.jsonl"));
+    touch(&omp_current);
+    touch(&omp_other);
+    touch(&omp_sessions.join("--newest--").join(format!("2026-09-01T10-00-00-000Z_{OTHER_ID}.jsonl")));
+    assert_eq!(
+        omp::find_transcript_by_id(
+            &omp_sessions,
+            &lookup_cwd,
+            &lookup_spelling(&home),
+            &std::env::temp_dir(),
+            ID,
+        )
+        .expect("omp"),
+        Some(omp_current)
+    );
+    assert_eq!(
+        omp::find_transcript_by_id(
+            &omp_sessions,
+            &lookup_cwd,
+            &lookup_spelling(&home),
+            &std::env::temp_dir(),
+            "missing",
+        )
+        .expect("miss"),
+        None
+    );
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+fn exact_database_ids_do_not_select_a_newer_unrelated_session() {
+    let root = temp_dir("database hosts");
+
+    let hermes_db = root.join("Hermes Home ü/state.db");
+    std::fs::create_dir_all(hermes_db.parent().expect("Hermes parent")).expect("Hermes parent");
+    let hermes_writer = Connection::open(&hermes_db).expect("Hermes database");
+    hermes_writer
+        .execute_batch(
+            "CREATE TABLE messages (
+                id INTEGER PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                timestamp REAL NOT NULL,
+                active INTEGER NOT NULL
+            );",
+        )
+        .expect("Hermes schema");
+    for (id, text, timestamp) in [(ID, "named", 1.0), (OTHER_ID, "newer unrelated", 2.0)] {
+        hermes_writer
+            .execute(
+                "INSERT INTO messages (session_id, role, content, timestamp, active) \
+                 VALUES (?1, 'assistant', ?2, ?3, 1)",
+                params![id, text, timestamp],
+            )
+            .expect("Hermes message");
+    }
+    assert_eq!(
+        hermes::messages_for_session(&hermes_db, ID, 1)
+            .expect("Hermes exact")
+            .first()
+            .expect("Hermes message")
+            .text,
+        "named"
+    );
+    assert!(matches!(
+        hermes::messages_for_session(&hermes_db, "missing", 1),
+        Err(HostError::NoMessages(message)) if message.contains(&hermes_db.display().to_string())
+    ));
+    drop(hermes_writer);
+
+    let opencode_db = root.join("OpenCode Data ü/opencode.db");
+    std::fs::create_dir_all(opencode_db.parent().expect("OpenCode parent")).expect("OpenCode parent");
+    let opencode_writer = Connection::open(&opencode_db).expect("OpenCode database");
+    opencode_writer
+        .execute_batch(
+            "CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                parent_id TEXT,
+                directory TEXT NOT NULL,
+                time_updated INTEGER NOT NULL,
+                time_archived INTEGER
+            );",
+        )
+        .expect("OpenCode schema");
+    for (id, updated) in [(ID, 1), (OTHER_ID, 2)] {
+        opencode_writer
+            .execute(
+                "INSERT INTO session (id, directory, time_updated) VALUES (?1, 'C:/work tree', ?2)",
+                params![id, updated],
+            )
+            .expect("OpenCode session");
+    }
+    assert_eq!(opencode::schema_of(&opencode_db, ID).expect("OpenCode exact"), opencode::Schema::V1);
+    assert!(matches!(
+        opencode::schema_of(&opencode_db, "missing"),
+        Err(HostError::NoMessages(message)) if message.contains(&opencode_db.display().to_string())
+    ));
+    drop(opencode_writer);
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+fn assert_invalid<T>(result: &Result<T, HostError>) {
+    assert!(
+        matches!(result, Err(HostError::InvalidSessionId(_))),
+        "filesystem/database access must not replace validation"
+    );
+}
+
+#[test]
+fn malformed_ids_are_rejected_before_any_store_access() {
+    let missing = Path::new("root that does not exist ü");
+    for id in ["", " ", "..", "a..b", "../id", "dir/id", "dir\\id", "nul\0id"] {
+        assert_invalid(&claude::find_transcript_by_id(missing, missing, id));
+        assert_invalid(&codex::find_transcripts_by_id(missing, id));
+        assert_invalid(&copilot::find_session_by_id(missing, id));
+        assert_invalid(&droid::find_transcript_by_id(missing, missing, id));
+        assert_invalid(&pi::find_transcript_by_id(missing, missing, id));
+        assert_invalid(&omp::find_transcript_by_id(missing, missing, missing, missing, id));
+        assert_invalid(&hermes::messages_for_session(missing, id, 1));
+        assert_invalid(&opencode::schema_of(missing, id));
+    }
+}

--- a/crates/plannotator-tui-hosts/tests/opencode.rs
+++ b/crates/plannotator-tui-hosts/tests/opencode.rs
@@ -31,6 +31,14 @@ CREATE TABLE session_message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, typ
 CREATE UNIQUE INDEX session_message_session_seq_idx ON session_message (session_id, seq);
 ";
 
+/// Current `OpenCode` writes this table alongside the legacy message/part tables while the
+/// session row remains in `session`.
+const CURRENT_SESSION_MESSAGE: &str = "
+CREATE TABLE session_message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, type TEXT NOT NULL,
+    seq INTEGER NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL,
+    data TEXT NOT NULL);
+";
+
 fn session_v2(
     c: &Connection,
     id: &str,
@@ -134,6 +142,25 @@ fn a_database_without_the_v2_tables_still_reads_v1() {
     let db = dir.join("opencode.db");
     let writer = populate(&db);
     assert_eq!(opencode::find_session(&db, Path::new("/work/app")).expect("v1").schema, Schema::V1);
+    drop(writer);
+    std::fs::remove_dir_all(&dir).expect("cleanup");
+}
+
+#[test]
+fn current_schema_keeps_exact_ids_on_the_session_message_compatibility_path() {
+    let dir = temp_dir("current");
+    let db = dir.join("opencode.db");
+    let writer = populate(&db);
+    writer.execute_batch(CURRENT_SESSION_MESSAGE).expect("current session_message table");
+    writer
+        .execute(
+            "INSERT INTO session_message (id, session_id, type, seq, time_created, time_updated, data) VALUES ('current-only', 'ses_main', 'assistant', 1, 60, 60, '{\"content\":[{\"type\":\"text\",\"text\":\"duplicate current row\"}]}')",
+            [],
+        )
+        .expect("current row");
+    assert_eq!(opencode::schema_of(&db, "ses_main").expect("schema"), Schema::V1);
+    let messages = opencode::messages_for_session(&db, "ses_main", Schema::V1, 1).expect("messages");
+    assert_eq!(messages[0].text, "newest reply");
     drop(writer);
     std::fs::remove_dir_all(&dir).expect("cleanup");
 }

--- a/crates/plannotator-tui/src/cli.rs
+++ b/crates/plannotator-tui/src/cli.rs
@@ -145,7 +145,7 @@ fn show_config() -> Result<()> {
 
 /// `plannotator-tui herdr open [PATH] [--placement P] [--deliver-to PANE]`.
 fn herdr_command(args: &[String]) -> Result<()> {
-    use crate::herdr::launch::{OpenArgs, agent_get, plan, plan_last, process_info, run};
+    use crate::herdr::launch::{OpenArgs, agent_get, agent_identity, plan, plan_last, process_info, run};
     let sub = args.first().map(String::as_str);
     if sub == Some("pane") {
         return herdr_pane();
@@ -177,7 +177,11 @@ fn herdr_command(args: &[String]) -> Result<()> {
         let pane = probe.deliver.as_ref().map(|t| t.pane.clone()).or(probe.target_pane);
         let pane = pane.context("no agent pane to read: not focused on one and no --deliver-to")?;
         let agent = agent_get(&env, &pane);
-        plan_last(&env, &config, open, &cwd, &process_info(&env, &pane)?, agent.as_deref())?
+        let process = match agent.as_deref().and_then(agent_identity) {
+            Some(_) => None,
+            None => Some(process_info(&env, &pane)?),
+        };
+        plan_last(&env, &config, open, &cwd, process.as_deref(), agent.as_deref())?
     } else {
         plan(&env, &config, open, &cwd)?
     };
@@ -187,10 +191,10 @@ fn herdr_command(args: &[String]) -> Result<()> {
 /// The pane entrypoint: Herdr runs this in the opened pane; the environment says what to show.
 fn herdr_pane() -> Result<()> {
     let env = HerdrEnv::from_env();
-    let result = if let Some(pid) = env.message_pid {
+    let result = if env.has_message_source() {
         crate::last::run(&crate::last::LastOptions {
             host: env.host.clone(),
-            pid: Some(pid),
+            pid: env.message_pid,
             session: env.session.clone(),
             session_id: env.session_id.clone(),
             pick: 25,

--- a/crates/plannotator-tui/src/delivery.rs
+++ b/crates/plannotator-tui/src/delivery.rs
@@ -144,7 +144,12 @@ pub(crate) fn parse_response(success: bool, _stdout: &str, stderr: &str) -> Resu
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "tests assert by panicking")]
+#[allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::unwrap_used,
+    reason = "tests assert by panicking"
+)]
 mod tests {
     use super::*;
 

--- a/crates/plannotator-tui/src/delivery.rs
+++ b/crates/plannotator-tui/src/delivery.rs
@@ -189,4 +189,31 @@ mod tests {
         );
         assert_eq!(HerdrAgent::new(bin, "w1:p1".into(), None).describe(), "w1:p1");
     }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_create_process_keeps_feedback_in_one_argument() {
+        let root = std::env::var_os("RUNNER_TEMP")
+            .map_or_else(std::env::temp_dir, PathBuf::from)
+            .join(format!("plannotator delivery proof ü-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("temp root");
+        let fake = root.join("fake herdr.exe");
+        let source = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/support/fake-herdr.rs");
+        let output = Command::new("rustc")
+            .arg("--edition=2024")
+            .arg(source)
+            .arg("-o")
+            .arg(&fake)
+            .output()
+            .expect("run rustc");
+        assert!(output.status.success(), "rustc failed: {}", String::from_utf8_lossy(&output.stderr));
+        let feedback = "line one\n\"quoted\" 100% & ready | café 中文";
+        HerdrAgent::new(fake, "w1:p1".into(), Some("codex".into())).deliver(feedback).expect("delivered");
+        let log = std::fs::read_to_string(root.join("calls.jsonl")).expect("call log");
+        let call: serde_json::Value = serde_json::from_str(log.trim()).expect("JSON call");
+        assert_eq!(call["argv"], serde_json::json!(["agent", "prompt", "w1:p1", feedback]));
+        assert_eq!(call["argv"].as_array().expect("argv").len(), 4);
+        std::fs::remove_dir_all(root).expect("cleanup");
+    }
 }

--- a/crates/plannotator-tui/src/herdr/context.rs
+++ b/crates/plannotator-tui/src/herdr/context.rs
@@ -97,6 +97,11 @@ impl HerdrEnv {
         self.focused_agent_pane()
     }
 
+    /// Whether the pane entrypoint opens an agent message rather than a file.
+    pub(crate) fn has_message_source(&self) -> bool {
+        self.session.is_some() || self.session_id.is_some() || self.message_pid.is_some()
+    }
+
     /// Ask Herdr which agent runs in `pane` (`herdr pane get`), for the label when the
     /// launcher only knew the pane id. One short process at startup; `None` on any failure.
     pub(crate) fn agent_in_pane(&self, pane: &str) -> Option<String> {
@@ -173,5 +178,17 @@ mod tests {
         let env = env(&[("HERDR_ENV", "1"), ("HERDR_PANE_ID", "w1:p3")]);
         assert_eq!(env.pane_id.as_deref(), Some("w1:p3"));
         assert_eq!(env.delivery_target(), None);
+    }
+
+    #[test]
+    fn any_exact_session_or_pid_selects_the_message_entrypoint() {
+        for vars in [
+            vec![("PLANNOTATOR_TUI_SESSION", "C:\\sessions\\one.jsonl")],
+            vec![("PLANNOTATOR_TUI_SESSION_ID", "session-one")],
+            vec![("PLANNOTATOR_TUI_MESSAGE_PID", "42")],
+        ] {
+            assert!(env(&vars).has_message_source());
+        }
+        assert!(!env(&[]).has_message_source());
     }
 }

--- a/crates/plannotator-tui/src/herdr/launch.rs
+++ b/crates/plannotator-tui/src/herdr/launch.rs
@@ -35,10 +35,16 @@ pub(crate) struct Launch {
     pub(crate) deliver: Option<Target>,
     /// The plugin id to open under: whatever plugin ships this binary.
     pub(crate) plugin: String,
-    /// Open an agent's last message instead of `file`: (pid, host label).
-    pub(crate) message: Option<(u32, String)>,
+    /// Open an agent's last message instead of `file`.
+    pub(crate) message: Option<AgentMessage>,
     /// The agent's session as Herdr reports it: a transcript path or a host-specific id.
     pub(crate) session: Option<AgentSession>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AgentMessage {
+    pub(crate) host: String,
+    pub(crate) pid: Option<u32>,
 }
 
 /// `agent_session` from `herdr agent get`: the exact transcript when Herdr knows it.
@@ -52,10 +58,13 @@ pub(crate) enum AgentSession {
 pub(crate) fn agent_session(agent_get_json: &str) -> Option<AgentSession> {
     let json: serde_json::Value = serde_json::from_str(agent_get_json).ok()?;
     let session = json.pointer("/result/agent/agent_session")?;
-    let value = session.get("value")?.as_str()?.to_owned();
+    let value = session.get("value")?.as_str()?;
+    if value.trim().is_empty() {
+        return None;
+    }
     match session.get("kind")?.as_str()? {
-        "path" => Some(AgentSession::Path(value)),
-        "id" => Some(AgentSession::Id(value)),
+        "path" => Some(AgentSession::Path(value.to_owned())),
+        "id" => Some(AgentSession::Id(value.to_owned())),
         _ => None,
     }
 }
@@ -65,6 +74,11 @@ fn agent_host(agent_get_json: &str) -> Option<&'static str> {
     let json: serde_json::Value = serde_json::from_str(agent_get_json).ok()?;
     let label = json.pointer("/result/agent/agent")?.as_str()?;
     Host::ALL.into_iter().find(|host| host.label() == label).map(Host::label)
+}
+
+/// A supported host plus the exact session reference Herdr reported.
+pub(crate) fn agent_identity(agent_get_json: &str) -> Option<(String, AgentSession)> {
+    Some((agent_host(agent_get_json)?.to_owned(), agent_session(agent_get_json)?))
 }
 
 /// The agent process behind a pane, from `herdr pane process-info --pane <id>` JSON: the
@@ -102,14 +116,14 @@ fn known_host(name: &str) -> Option<&'static str> {
     }
 }
 
-/// Resolve a `last` launch: the target pane as for `open`, the folder from the context, and
-/// the agent process from the pane's process info (fetched by the caller).
+/// Resolve a `last` launch. An exact Herdr session needs no process metadata; otherwise the
+/// caller supplies the pane's process info as the fallback.
 pub(crate) fn plan_last(
     env: &HerdrEnv,
     config: &Config,
     args: OpenArgs,
     cwd: &Path,
-    process_info_json: &str,
+    process_info_json: Option<&str>,
     agent_get_json: Option<&str>,
 ) -> Result<Launch> {
     let mut launch = plan(env, config, OpenArgs { path: None, ..args }, cwd)?;
@@ -117,13 +131,19 @@ pub(crate) fn plan_last(
     let Some(pane) = pane else {
         anyhow::bail!("no agent pane to read: not focused on one and no --deliver-to")
     };
-    let Some((pid, process_host)) = agent_pid(process_info_json) else {
+    launch.file.clone_from(&launch.cwd);
+    if let Some((host, session)) = agent_get_json.and_then(agent_identity) {
+        launch.message = Some(AgentMessage { host, pid: None });
+        launch.session = Some(session);
+        return Ok(launch);
+    }
+    let process_info = process_info_json
+        .with_context(|| format!("no exact agent session or process info for pane {pane}"))?;
+    let Some((pid, process_host)) = agent_pid(process_info) else {
         anyhow::bail!("no agent process found in pane {pane}");
     };
     let host = agent_get_json.and_then(agent_host).unwrap_or(&process_host).to_owned();
-    launch.file.clone_from(&launch.cwd);
-    launch.message = Some((pid, host));
-    launch.session = agent_get_json.and_then(agent_session);
+    launch.message = Some(AgentMessage { host, pid: Some(pid) });
     Ok(launch)
 }
 
@@ -241,9 +261,11 @@ pub(crate) fn argv(launch: &Launch) -> Vec<String> {
     out.push("--focus".to_owned());
     out.extend(["--cwd".to_owned(), launch.cwd.display().to_string()]);
     match &launch.message {
-        Some((pid, host)) => {
-            out.extend(["--env".to_owned(), format!("PLANNOTATOR_TUI_MESSAGE_PID={pid}")]);
-            out.extend(["--env".to_owned(), format!("PLANNOTATOR_TUI_HOST={host}")]);
+        Some(message) => {
+            if let Some(pid) = message.pid {
+                out.extend(["--env".to_owned(), format!("PLANNOTATOR_TUI_MESSAGE_PID={pid}")]);
+            }
+            out.extend(["--env".to_owned(), format!("PLANNOTATOR_TUI_HOST={}", message.host)]);
             out.extend(["--env".to_owned(), format!("PLANNOTATOR_TUI_CWD={}", launch.cwd.display())]);
             match &launch.session {
                 Some(AgentSession::Path(p)) => {

--- a/crates/plannotator-tui/src/herdr/launch/tests.rs
+++ b/crates/plannotator-tui/src/herdr/launch/tests.rs
@@ -186,11 +186,11 @@ fn a_last_launch_carries_the_pid_and_host_instead_of_a_file() {
         &Config::default(),
         OpenArgs::default(),
         Path::new("/"),
-        PROCESS_INFO,
+        Some(PROCESS_INFO),
         None,
     )
     .expect("plans");
-    assert_eq!(launch.message, Some((91279, "claude".into())));
+    assert_eq!(launch.message, Some(AgentMessage { host: "claude".into(), pid: Some(91279) }));
     assert_eq!(launch.deliver.as_ref().map(|t| t.pane.as_str()), Some("w1:p1"));
     let args = argv(&launch);
     assert!(args.contains(&"PLANNOTATOR_TUI_MESSAGE_PID=91279".to_owned()));
@@ -203,10 +203,7 @@ const AGENT_GET_ID: &str = r#"{"id":"cli:agent:get","result":{"agent":{"agent":"
 const AGENT_GET_PI: &str = r#"{"id":"cli:agent:get","result":{"agent":{"agent":"pi","agent_session":{"agent":"pi","kind":"path","source":"herdr:pi","value":"~/.pi/agent/sessions/--w--/session.jsonl"},"pane_id":"w1:p1"},"type":"agent_info"}}"#;
 
 #[test]
-fn herdrs_agent_label_wins_when_an_agent_runs_through_node() {
-    let process_info = PROCESS_INFO
-        .replace(r#""argv0":"claude""#, r#""argv0":"pi""#)
-        .replace(r#""name":"claude""#, r#""name":"node""#);
+fn herdrs_exact_agent_identity_needs_no_process_info() {
     let context = HerdrContext {
         focused_pane_id: Some("w1:p1".into()),
         focused_pane_agent: Some("pi".into()),
@@ -218,12 +215,13 @@ fn herdrs_agent_label_wins_when_an_agent_runs_through_node() {
         &Config::default(),
         OpenArgs::default(),
         Path::new("/"),
-        &process_info,
+        None,
         Some(AGENT_GET_PI),
     )
     .expect("plans");
 
-    assert_eq!(launch.message, Some((91279, "pi".into())));
+    assert_eq!(launch.message, Some(AgentMessage { host: "pi".into(), pid: None }));
+    assert!(!argv(&launch).iter().any(|arg| arg.starts_with("PLANNOTATOR_TUI_MESSAGE_PID=")));
     assert!(argv(&launch).contains(&"PLANNOTATOR_TUI_HOST=pi".to_owned()));
 }
 
@@ -247,7 +245,7 @@ fn herdrs_agent_session_is_passed_to_the_pane_as_a_path_or_an_id() {
         &Config::default(),
         OpenArgs::default(),
         Path::new("/"),
-        &PROCESS_INFO.replace(r#""name":"claude""#, r#""name":"omp""#),
+        None,
         Some(AGENT_GET_PATH),
     )
     .expect("plans");
@@ -260,7 +258,7 @@ fn herdrs_agent_session_is_passed_to_the_pane_as_a_path_or_an_id() {
         &Config::default(),
         OpenArgs::default(),
         Path::new("/"),
-        PROCESS_INFO,
+        None,
         Some(AGENT_GET_ID),
     )
     .expect("plans");

--- a/crates/plannotator-tui/src/last/exact.rs
+++ b/crates/plannotator-tui/src/last/exact.rs
@@ -1,0 +1,73 @@
+//! Resolve a validated exact session id without falling through to heuristic discovery.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use plannotator_tui_hosts::{Host, claude, codex, copilot, droid, omp, opencode, pi};
+
+use super::roots::Roots;
+
+pub(super) enum ExactSession {
+    File(PathBuf),
+    Codex(Vec<PathBuf>),
+    Hermes(PathBuf),
+    OpenCode { database: PathBuf, schema: opencode::Schema },
+}
+
+pub(super) fn resolve(host: Host, session_id: &str, cwd: &Path, roots: &Roots) -> Result<ExactSession> {
+    let id = plannotator_tui_hosts::validate_session_id(session_id)?;
+    match host {
+        Host::ClaudeCode => {
+            let projects = roots.claude_config.join("projects");
+            claude::find_transcript_by_id(&projects, cwd, id)?
+                .map(ExactSession::File)
+                .with_context(|| format!("no Claude Code session {id} in {}", projects.display()))
+        }
+        Host::Codex => {
+            let files = codex::find_transcripts_by_id(&roots.codex_home, id)?;
+            if files.is_empty() {
+                bail!("no Codex session {id} in {}", roots.codex_home.join("sessions").display());
+            }
+            Ok(ExactSession::Codex(files))
+        }
+        Host::Copilot => {
+            let root = roots.copilot_home.join("session-state");
+            copilot::find_session_by_id(&roots.copilot_home, id)?
+                .map(ExactSession::File)
+                .with_context(|| format!("no Copilot CLI session {id} in {}", root.display()))
+        }
+        Host::Droid => {
+            let root = roots.factory_config.join("sessions");
+            droid::find_transcript_by_id(&roots.factory_config, cwd, id)?
+                .map(ExactSession::File)
+                .with_context(|| format!("no Droid session {id} in {}", root.display()))
+        }
+        Host::Pi => {
+            let root = roots.pi_sessions(".pi/agent");
+            pi::find_transcript_by_id(&root, cwd, id)?
+                .map(ExactSession::File)
+                .with_context(|| format!("no pi session {id} in {}", root.display()))
+        }
+        Host::Omp => {
+            let root = roots.pi_sessions(omp::DEFAULT_AGENT_DIR);
+            omp::find_transcript_by_id(&root, cwd, &roots.home, &std::env::temp_dir(), id)?
+                .map(ExactSession::File)
+                .with_context(|| format!("no omp session {id} in {}", root.display()))
+        }
+        Host::Hermes => Ok(ExactSession::Hermes(roots.hermes_database())),
+        Host::OpenCode => {
+            let databases = roots.opencode_databases();
+            let found = databases
+                .iter()
+                .find_map(|database| {
+                    opencode::schema_of(database, id).ok().map(|schema| (database.clone(), schema))
+                })
+                .with_context(|| format!("no OpenCode session {id} in {}", describe(&databases)))?;
+            Ok(ExactSession::OpenCode { database: found.0, schema: found.1 })
+        }
+    }
+}
+
+pub(super) fn describe(paths: &[PathBuf]) -> String {
+    paths.iter().map(|path| path.display().to_string()).collect::<Vec<_>>().join(", ")
+}

--- a/crates/plannotator-tui/src/last/fallback.rs
+++ b/crates/plannotator-tui/src/last/fallback.rs
@@ -5,7 +5,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result, bail};
-use plannotator_tui_hosts::{Host, Message, claude, copilot, droid, opencode, pi};
+#[cfg(unix)]
+use plannotator_tui_hosts::copilot;
+use plannotator_tui_hosts::{Host, Message, claude, droid, opencode, pi};
 
 use super::LastOptions;
 use super::exact;

--- a/crates/plannotator-tui/src/last/fallback.rs
+++ b/crates/plannotator-tui/src/last/fallback.rs
@@ -1,0 +1,151 @@
+//! PID metadata and cwd/mtime discovery after no exact path or id was supplied.
+
+use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use plannotator_tui_hosts::{Host, Message, claude, copilot, droid, opencode, pi};
+
+use super::LastOptions;
+use super::exact;
+use super::readers;
+use super::roots::Roots;
+
+pub(super) fn read(
+    host: Host,
+    options: &LastOptions,
+    cwd: &Path,
+    roots: &Roots,
+    pick: usize,
+) -> Result<(PathBuf, Vec<Message>)> {
+    match host {
+        Host::ClaudeCode => {
+            let path = find_claude_transcript(options.pid, cwd, roots)?;
+            let messages = readers::claude_messages(&path, pick)?;
+            Ok((path, messages))
+        }
+        Host::Codex => {
+            let thread = std::env::var("CODEX_THREAD_ID").ok().filter(|thread| !thread.is_empty());
+            readers::codex_thread(&roots.codex_home, thread.as_deref(), pick)
+        }
+        Host::Copilot => {
+            let path = find_copilot_session(options.pid, cwd, roots)?;
+            let messages = readers::copilot_messages(&path, pick)?;
+            Ok((path, messages))
+        }
+        Host::Droid => {
+            let path = find_droid_transcript(cwd, roots)?;
+            let messages = readers::droid_messages(&path, pick)?;
+            Ok((path, messages))
+        }
+        Host::Pi => {
+            let path = find_pi_transcript(cwd, roots, ".pi/agent", "pi")?;
+            let messages = readers::pi_messages(&path, pick)?;
+            Ok((path, messages))
+        }
+        Host::Omp => bail!(
+            "OMP session discovery without an exact path or id is unsupported; pass --session or --session-id"
+        ),
+        Host::Hermes => bail!("hermes needs a session id (Herdr provides it; or pass --session-id)"),
+        Host::OpenCode => opencode_for_cwd(cwd, roots, pick),
+    }
+}
+
+fn find_claude_transcript(pid: Option<u32>, cwd: &Path, roots: &Roots) -> Result<PathBuf> {
+    let sessions_dir = roots.claude_config.join("sessions");
+    let projects_dir = roots.claude_config.join("projects");
+    let (start_pid, table) = process_context(pid);
+    claude::find_transcript(&sessions_dir, &projects_dir, cwd, &table, start_pid).ok_or_else(|| {
+        anyhow::anyhow!(
+            "no Claude Code transcript for pid {start_pid} (looked in {} and {})",
+            sessions_dir.display(),
+            projects_dir.join(claude::project_slug(cwd)).display()
+        )
+    })
+}
+
+#[cfg(unix)]
+fn find_copilot_session(pid: Option<u32>, cwd: &Path, roots: &Roots) -> Result<PathBuf> {
+    let (start_pid, table) = process_context(pid);
+    copilot::find_session(&roots.copilot_home, cwd, &table, start_pid, is_copilot_process).ok_or_else(|| {
+        anyhow::anyhow!(
+            "no Copilot CLI session for pid {start_pid} or {} (looked in {})",
+            cwd.display(),
+            roots.copilot_home.join("session-state").display()
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn find_copilot_session(_pid: Option<u32>, _cwd: &Path, _roots: &Roots) -> Result<PathBuf> {
+    bail!("Copilot session discovery without --session-id is unsupported on Windows; pass --session-id")
+}
+
+/// Does `pid` still name a Copilot process? Locks outlive sessions and pids get reused.
+#[cfg(unix)]
+fn is_copilot_process(pid: u32) -> bool {
+    Command::new("ps")
+        .args(["-o", "comm=", "-p", &pid.to_string()])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+        .is_some_and(|name| name.rsplit('/').next().unwrap_or(&name).starts_with("copilot"))
+}
+
+fn find_droid_transcript(cwd: &Path, roots: &Roots) -> Result<PathBuf> {
+    droid::find_transcript(&roots.factory_config, cwd).ok_or_else(|| {
+        anyhow::anyhow!(
+            "no Droid session for {} (looked in {})",
+            cwd.display(),
+            roots.factory_config.join("sessions").join(claude::project_slug(cwd)).display()
+        )
+    })
+}
+
+fn find_pi_transcript(cwd: &Path, roots: &Roots, default_agent_dir: &str, label: &str) -> Result<PathBuf> {
+    let sessions_dir = roots.pi_sessions(default_agent_dir);
+    pi::find_transcript(&sessions_dir, cwd).ok_or_else(|| {
+        anyhow::anyhow!("no {label} session for {} (looked in {})", cwd.display(), sessions_dir.display())
+    })
+}
+
+#[cfg(unix)]
+fn process_context(pid: Option<u32>) -> (u32, Vec<(u32, u32)>) {
+    (pid.unwrap_or_else(std::os::unix::process::parent_id), process_table())
+}
+
+#[cfg(not(unix))]
+fn process_context(pid: Option<u32>) -> (u32, Vec<(u32, u32)>) {
+    (pid.unwrap_or(0), Vec::new())
+}
+
+/// One POSIX `ps` snapshot; an empty table when it cannot run.
+#[cfg(unix)]
+fn process_table() -> Vec<(u32, u32)> {
+    Command::new("ps")
+        .args(["-eo", "pid=,ppid="])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| claude::parse_ps(&String::from_utf8_lossy(&output.stdout)))
+        .unwrap_or_default()
+}
+
+fn opencode_for_cwd(cwd: &Path, roots: &Roots, pick: usize) -> Result<(PathBuf, Vec<Message>)> {
+    let databases = roots.opencode_databases();
+    let mut best: Option<(PathBuf, opencode::Found)> = None;
+    for database in &databases {
+        if let Ok(found) = opencode::find_session(database, cwd)
+            && best.as_ref().is_none_or(|(_, current)| found.updated > current.updated)
+        {
+            best = Some((database.clone(), found));
+        }
+    }
+    let (database, found) = best.with_context(|| {
+        format!("no OpenCode session for {} in {}", cwd.display(), exact::describe(&databases))
+    })?;
+    let messages = opencode::messages_for_session(&database, &found.id, found.schema, pick)?;
+    Ok((database, messages))
+}

--- a/crates/plannotator-tui/src/last/locate.rs
+++ b/crates/plannotator-tui/src/last/locate.rs
@@ -1,17 +1,14 @@
-//! Find the transcript and read its recent assistant messages. The only module that looks
-//! at the home directory, the environment, or the process table.
+//! Select the exact-session or fallback discovery path and read its assistant messages.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result, bail};
-use plannotator_tui_hosts::{
-    Host, HostError, Message, Role, claude, codex, copilot, detect_host, droid, hermes, omp, opencode, pi,
-    sniff,
-};
+use plannotator_tui_hosts::{Host, HostError, Message, Role, detect_host, sniff};
 use plannotator_tui_schema::{DocumentSource, Provenance};
 
-use super::LastOptions;
+use super::roots::Roots;
+use super::{LastOptions, exact, fallback, readers};
 
 pub(crate) struct Located {
     pub(crate) host: Host,
@@ -30,82 +27,21 @@ pub(crate) fn locate(options: &LastOptions) -> Result<Located> {
         _ => host_for(options)?,
     };
     let pick = options.pick.max(1);
-    let (transcript, messages) = match (host, &session) {
-        (Host::ClaudeCode, Some(path)) => (path.clone(), claude_messages(path, pick)?),
-        (Host::ClaudeCode, None) => {
-            let path = find_claude_transcript(options.pid)?;
-            let messages = claude_messages(&path, pick)?;
-            (path, messages)
-        }
-        (Host::Codex, Some(path)) if path.is_dir() => codex_thread(path, None, pick)?,
-        (Host::Codex, Some(path)) => (path.clone(), codex_messages(std::slice::from_ref(path), pick)?),
-        (Host::Codex, None) => {
-            let home = std::env::var_os("CODEX_HOME").map_or_else(|| home().join(".codex"), PathBuf::from);
-            let thread = std::env::var("CODEX_THREAD_ID").ok().filter(|t| !t.is_empty());
-            codex_thread(&home, thread.as_deref(), pick)?
-        }
-        (Host::Copilot, Some(dir)) => (dir.clone(), copilot_messages(dir, pick)?),
-        (Host::Copilot, None) => {
-            let dir = find_copilot_session(options.pid)?;
-            let messages = copilot_messages(&dir, pick)?;
-            (dir, messages)
-        }
-        (Host::Droid, Some(path)) => (path.clone(), droid_messages(path, pick)?),
-        (Host::Droid, None) => {
-            let path = find_droid_transcript()?;
-            let messages = droid_messages(&path, pick)?;
-            (path, messages)
-        }
-        (Host::Pi, Some(path)) => (path.clone(), pi_messages(path, pick)?),
-        (Host::Pi, None) => {
-            let path = find_pi_transcript(".pi/agent", "pi")?;
-            let messages = pi_messages(&path, pick)?;
-            (path, messages)
-        }
-        (Host::Omp, Some(path)) => (path.clone(), omp_messages(path, pick)?),
-        (Host::Omp, None) => {
-            let path = find_pi_transcript(omp::DEFAULT_AGENT_DIR, "omp")?;
-            let messages = omp_messages(&path, pick)?;
-            (path, messages)
-        }
-        (Host::Hermes, _) => {
-            let Some(id) = options.session_id.as_deref().filter(|s| !s.trim().is_empty()) else {
-                bail!("hermes needs a session id (Herdr provides it; or pass --session-id)");
-            };
-            let db =
-                std::env::var_os("HERMES_HOME").map_or_else(hermes_home, PathBuf::from).join(hermes::DB_FILE);
-            let messages = hermes::messages_for_session(&db, id, pick)?;
-            (db, messages)
-        }
-        (Host::OpenCode, _) => {
-            let databases = opencode_databases();
-            let named = options.session_id.as_deref().filter(|s| !s.trim().is_empty());
-            let (db, id, schema) = if let Some(id) = named {
-                let (db, schema) = databases
-                    .iter()
-                    .find_map(|db| opencode::schema_of(db, id).ok().map(|schema| (db.clone(), schema)))
-                    .with_context(|| format!("no OpenCode session {id} in {}", describe(&databases)))?;
-                (db, id.to_owned(), schema)
-            } else {
-                let cwd = agent_cwd()?;
-                let mut best: Option<(PathBuf, opencode::Found)> = None;
-                for db in &databases {
-                    if let Ok(found) = opencode::find_session(db, &cwd)
-                        && best.as_ref().is_none_or(|(_, b)| found.updated > b.updated)
-                    {
-                        best = Some((db.clone(), found));
-                    }
-                }
-                let (db, found) = best.with_context(|| {
-                    format!("no OpenCode session for {} in {}", cwd.display(), describe(&databases))
-                })?;
-                (db, found.id, found.schema)
-            };
-            let messages = opencode::messages_for_session(&db, &id, schema, pick)?;
-            (db, messages)
-        }
+    let roots = Roots::from_env();
+    let (transcript, messages) = if let Some(path) = session {
+        readers::explicit(host, &path, options.session_id.as_deref(), pick)?
+    } else if let Some(id) = options.session_id.as_deref() {
+        // Validation precedes cwd lookup and every resolver filesystem access.
+        let id = plannotator_tui_hosts::validate_session_id(id)?;
+        let cwd = agent_cwd()?;
+        let exact = exact::resolve(host, id, &cwd, &roots)?;
+        readers::exact(host, id, exact, pick)?
+    } else {
+        let cwd = agent_cwd()?;
+        fallback::read(host, options, &cwd, &roots, pick)?
     };
-    let messages: Vec<Message> = messages.into_iter().filter(|m| m.role == Role::Assistant).collect();
+    let messages: Vec<Message> =
+        messages.into_iter().filter(|message| message.role == Role::Assistant).collect();
     if messages.is_empty() {
         bail!("transcript {} has no assistant messages yet", transcript.display());
     }
@@ -114,8 +50,8 @@ pub(crate) fn locate(options: &LastOptions) -> Result<Located> {
 
 /// Was a host named explicitly, by flag or by the launcher?
 fn host_named(options: &LastOptions) -> bool {
-    options.host.as_deref().is_some_and(|h| !h.trim().is_empty())
-        || std::env::var("PLANNOTATOR_TUI_HOST").is_ok_and(|h| !h.trim().is_empty())
+    options.host.as_deref().is_some_and(|host| !host.trim().is_empty())
+        || std::env::var("PLANNOTATOR_TUI_HOST").is_ok_and(|host| !host.trim().is_empty())
 }
 
 /// The first 64 KiB of a transcript, enough for `sniff`.
@@ -123,15 +59,15 @@ fn head(path: &Path) -> Result<String> {
     use std::io::Read as _;
     let mut file = std::fs::File::open(path).with_context(|| format!("reading {}", path.display()))?;
     let mut bytes = vec![0u8; 64 * 1024];
-    let n = file.read(&mut bytes).with_context(|| format!("reading {}", path.display()))?;
-    bytes.truncate(n);
+    let count = file.read(&mut bytes).with_context(|| format!("reading {}", path.display()))?;
+    bytes.truncate(count);
     Ok(String::from_utf8_lossy(&bytes).into_owned())
 }
 
 /// `~/x` as Herdr reports some session paths.
 fn expand_home(path: &Path) -> PathBuf {
-    match path.to_str().and_then(|s| s.strip_prefix("~/")) {
-        Some(rest) => home().join(rest),
+    match path.to_str().and_then(|text| text.strip_prefix("~/")) {
+        Some(rest) => Roots::from_env().home.join(rest),
         None => path.to_path_buf(),
     }
 }
@@ -145,10 +81,18 @@ fn host_for(options: &LastOptions) -> Result<Host> {
     match detect_host(lookup) {
         Ok(host) => Ok(host),
         Err(HostError::Unsupported(name)) => {
-            let supported: Vec<&str> = Host::ALL.iter().map(|h| h.label()).collect();
+            let supported: Vec<&str> = Host::ALL.iter().map(|host| host.label()).collect();
             bail!("{name} is not supported yet; supported hosts: {} (or use --stdin)", supported.join(", "))
         }
         Err(err) => Err(err.into()),
+    }
+}
+
+/// The agent pane's cwd when the Herdr launcher set it, else our own.
+fn agent_cwd() -> Result<PathBuf> {
+    match std::env::var_os("PLANNOTATOR_TUI_CWD") {
+        Some(dir) => Ok(PathBuf::from(dir)),
+        None => std::env::current_dir().context("current directory"),
     }
 }
 
@@ -163,7 +107,7 @@ pub(crate) fn screen_fallback(env: &crate::herdr::context::HerdrEnv) -> Option<D
         .args(["agent", "read", &target.pane, "--source", "recent-unwrapped", "--format", "text"])
         .output()
         .ok()
-        .filter(|o| o.status.success())?;
+        .filter(|output| output.status.success())?;
     let text = String::from_utf8_lossy(&output.stdout).trim_end().to_owned();
     if text.is_empty() {
         return None;
@@ -175,209 +119,4 @@ pub(crate) fn screen_fallback(env: &crate::herdr::context::HerdrEnv) -> Option<D
         true,
         Provenance::AgentMessage { host, session: None, message_id: None },
     ))
-}
-
-/// Hermes' platform default (`hermes_constants.py`): `%LOCALAPPDATA%\hermes` on Windows,
-/// `~/.hermes` elsewhere.
-#[cfg(windows)]
-fn hermes_home() -> PathBuf {
-    std::env::var_os("LOCALAPPDATA")
-        .filter(|v| !v.is_empty())
-        .map_or_else(|| home().join("AppData").join("Local"), PathBuf::from)
-        .join("hermes")
-}
-
-#[cfg(not(windows))]
-fn hermes_home() -> PathBuf {
-    home().join(".hermes")
-}
-
-/// `OpenCode`'s databases: `$OPENCODE_DB` alone when set; else every `opencode*.db` in
-/// `<xdg data>/opencode` (`opencode.db` for the standard channels, `opencode-<channel>.db`
-/// for others), where the xdg data dir is `$XDG_DATA_HOME` or `~/.local/share`
-/// (`packages/util/src/global-roots.ts`, `packages/cli/src/server-process.ts`).
-fn opencode_databases() -> Vec<PathBuf> {
-    if let Some(db) = std::env::var_os("OPENCODE_DB").filter(|v| !v.is_empty()) {
-        return vec![PathBuf::from(db)];
-    }
-    let data = std::env::var_os("XDG_DATA_HOME")
-        .filter(|v| !v.is_empty())
-        .map_or_else(|| home().join(".local").join("share"), PathBuf::from)
-        .join(opencode::DATA_DIR);
-    let mut found: Vec<PathBuf> = std::fs::read_dir(&data)
-        .map(|entries| {
-            entries
-                .filter_map(Result::ok)
-                .map(|e| e.path())
-                .filter(|p| {
-                    p.file_name()
-                        .and_then(|n| n.to_str())
-                        .is_some_and(|n| n.starts_with("opencode") && n.to_ascii_lowercase().ends_with(".db"))
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-    found.sort();
-    if found.is_empty() {
-        found.push(data.join(opencode::DB_FILE));
-    }
-    found
-}
-
-fn describe(databases: &[PathBuf]) -> String {
-    databases.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ")
-}
-
-fn home() -> PathBuf {
-    std::env::home_dir().unwrap_or_else(|| PathBuf::from("/"))
-}
-
-/// The Claude Code ladder over the real `~/.claude`, starting from `pid` or our parent.
-fn find_claude_transcript(pid: Option<u32>) -> Result<PathBuf> {
-    let home = home();
-    let sessions_dir = home.join(".claude").join("sessions");
-    let projects_dir = home.join(".claude").join("projects");
-    let cwd = std::env::current_dir().context("current directory")?;
-    let start_pid = pid.unwrap_or_else(parent_pid);
-    let table = process_table();
-    claude::find_transcript(&sessions_dir, &projects_dir, &cwd, &table, start_pid).ok_or_else(|| {
-        anyhow::anyhow!(
-            "no Claude Code transcript for pid {start_pid} (looked in {} and {})",
-            sessions_dir.display(),
-            projects_dir.join(claude::project_slug(&cwd)).display()
-        )
-    })
-}
-
-/// Copilot's session directory via its lock files, from `pid` or our parent; the cwd
-/// heuristic when no ancestor holds a live lock.
-fn find_copilot_session(pid: Option<u32>) -> Result<PathBuf> {
-    let copilot_home =
-        std::env::var_os("COPILOT_HOME").map_or_else(|| home().join(".copilot"), PathBuf::from);
-    let cwd = std::env::current_dir().context("current directory")?;
-    let start_pid = pid.unwrap_or_else(parent_pid);
-    let table = process_table();
-    copilot::find_session(&copilot_home, &cwd, &table, start_pid, is_copilot_process).ok_or_else(|| {
-        anyhow::anyhow!(
-            "no Copilot CLI session for pid {start_pid} or {} (looked in {})",
-            cwd.display(),
-            copilot_home.join("session-state").display()
-        )
-    })
-}
-
-/// Does `pid` still name a Copilot process? Locks outlive sessions and pids get reused.
-fn is_copilot_process(pid: u32) -> bool {
-    Command::new("ps")
-        .args(["-o", "comm=", "-p", &pid.to_string()])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
-        .is_some_and(|name| name.rsplit('/').next().unwrap_or(&name).starts_with("copilot"))
-}
-
-fn copilot_messages(dir: &Path, pick: usize) -> Result<Vec<Message>> {
-    let events = dir.join("events.jsonl");
-    let text = std::fs::read_to_string(&events).with_context(|| format!("reading {}", events.display()))?;
-    Ok(copilot::parse_messages(&text, pick))
-}
-
-/// The agent pane's cwd when the Herdr launcher set it, else our own.
-fn agent_cwd() -> Result<PathBuf> {
-    match std::env::var_os("PLANNOTATOR_TUI_CWD") {
-        Some(dir) => Ok(PathBuf::from(dir)),
-        None => std::env::current_dir().context("current directory"),
-    }
-}
-
-/// Droid's current log for the cwd: no pid registry, so the newest log for the cwd's slug.
-fn find_droid_transcript() -> Result<PathBuf> {
-    let factory_dir =
-        std::env::var_os("FACTORY_CONFIG_DIR").map_or_else(|| home().join(".factory"), PathBuf::from);
-    let cwd = agent_cwd()?;
-    droid::find_transcript(&factory_dir, &cwd).ok_or_else(|| {
-        anyhow::anyhow!(
-            "no Droid session for {} (looked in {})",
-            cwd.display(),
-            factory_dir.join("sessions").join(claude::project_slug(&cwd)).display()
-        )
-    })
-}
-
-fn droid_messages(path: &Path, pick: usize) -> Result<Vec<Message>> {
-    let text = std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
-    Ok(droid::parse_messages(&text, pick))
-}
-
-/// Pi and OMP have no pid registry: the newest session for the agent's cwd, under the
-/// agent dir (`default_agent_dir` relative to `$HOME`; OMP reuses pi's override variables).
-fn find_pi_transcript(default_agent_dir: &str, label: &str) -> Result<PathBuf> {
-    let sessions_dir = match std::env::var_os("PI_CODING_AGENT_SESSION_DIR") {
-        Some(dir) => PathBuf::from(dir),
-        None => std::env::var_os("PI_CODING_AGENT_DIR")
-            .map_or_else(|| home().join(default_agent_dir), PathBuf::from)
-            .join("sessions"),
-    };
-    let cwd = agent_cwd()?;
-    pi::find_transcript(&sessions_dir, &cwd).ok_or_else(|| {
-        anyhow::anyhow!("no {label} session for {} (looked in {})", cwd.display(), sessions_dir.display())
-    })
-}
-
-fn omp_messages(path: &Path, pick: usize) -> Result<Vec<Message>> {
-    let text = std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
-    Ok(omp::parse_messages(&text, pick))
-}
-
-fn pi_messages(path: &Path, pick: usize) -> Result<Vec<Message>> {
-    let text = std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
-    Ok(pi::parse_messages(&text, pick))
-}
-
-#[cfg(unix)]
-fn parent_pid() -> u32 {
-    std::os::unix::process::parent_id()
-}
-
-#[cfg(not(unix))]
-fn parent_pid() -> u32 {
-    0
-}
-
-/// One `ps` snapshot; an empty table when it cannot run (the ladder then relies on cwd).
-fn process_table() -> Vec<(u32, u32)> {
-    Command::new("ps")
-        .args(["-eo", "pid=,ppid="])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| claude::parse_ps(&String::from_utf8_lossy(&o.stdout)))
-        .unwrap_or_default()
-}
-
-fn claude_messages(path: &Path, pick: usize) -> Result<Vec<Message>> {
-    let text = std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
-    Ok(claude::parse_messages(&text, pick))
-}
-
-fn codex_thread(codex_home: &Path, thread: Option<&str>, pick: usize) -> Result<(PathBuf, Vec<Message>)> {
-    let files = codex::find_transcripts(codex_home, thread);
-    let Some(newest) = files.last().cloned() else {
-        bail!(
-            "no Codex transcript under {} (thread {})",
-            codex_home.join("sessions").display(),
-            thread.unwrap_or("newest")
-        );
-    };
-    let messages = codex_messages(&files, pick)?;
-    Ok((newest, messages))
-}
-
-fn codex_messages(files: &[PathBuf], pick: usize) -> Result<Vec<Message>> {
-    let contents = files
-        .iter()
-        .map(|p| std::fs::read_to_string(p).with_context(|| format!("reading {}", p.display())))
-        .collect::<Result<Vec<String>>>()?;
-    Ok(codex::parse_messages(&contents, pick))
 }

--- a/crates/plannotator-tui/src/last/mod.rs
+++ b/crates/plannotator-tui/src/last/mod.rs
@@ -1,11 +1,15 @@
 //! `plannotator-tui last`: annotate an agent's most recent message (docs/spec-last-message.md).
 //!
-//! `locate` is the one impure step (home directory, process table, transcript files); the
-//! rest is the ordinary app over a transient document that is never written to disk.
+//! The modules here isolate home-directory, process-table, and transcript access from the
+//! ordinary app over a transient document that is never written to disk.
 
 #![allow(clippy::print_stdout, clippy::print_stderr, reason = "`--print` is a stdout contract")]
 
+mod exact;
+mod fallback;
 mod locate;
+mod readers;
+mod roots;
 
 use std::io::Read as _;
 use std::path::PathBuf;
@@ -26,7 +30,7 @@ pub(crate) struct LastOptions {
     pub(crate) pid: Option<u32>,
     /// An explicit transcript; skips detection. Its format is sniffed when no host is named.
     pub(crate) session: Option<PathBuf>,
-    /// A session id for hosts that keep conversations in a store rather than files (Hermes).
+    /// An exact host-specific session id; takes precedence over pid and cwd discovery.
     pub(crate) session_id: Option<String>,
     /// Read the document from stdin instead of a transcript.
     pub(crate) stdin: bool,

--- a/crates/plannotator-tui/src/last/readers.rs
+++ b/crates/plannotator-tui/src/last/readers.rs
@@ -1,0 +1,143 @@
+//! Read one already-selected transcript or database session.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use plannotator_tui_hosts::{Host, Message, claude, codex, copilot, droid, hermes, omp, opencode, pi};
+
+use super::exact::ExactSession;
+
+pub(super) fn explicit(
+    host: Host,
+    path: &Path,
+    session_id: Option<&str>,
+    pick: usize,
+) -> Result<(PathBuf, Vec<Message>)> {
+    match host {
+        Host::ClaudeCode => Ok((path.to_path_buf(), claude_messages(path, pick)?)),
+        Host::Codex if path.is_dir() => codex_thread(path, None, pick),
+        Host::Codex => {
+            let files = [path.to_path_buf()];
+            Ok((path.to_path_buf(), codex_messages(&files, pick)?))
+        }
+        Host::Copilot => Ok((path.to_path_buf(), copilot_messages(path, pick)?)),
+        Host::Droid => Ok((path.to_path_buf(), droid_messages(path, pick)?)),
+        Host::Pi => Ok((path.to_path_buf(), pi_messages(path, pick)?)),
+        Host::Omp => Ok((path.to_path_buf(), omp_messages(path, pick)?)),
+        Host::Hermes => {
+            let id = required_session_id(session_id, "hermes")?;
+            Ok((path.to_path_buf(), hermes::messages_for_session(path, id, pick)?))
+        }
+        Host::OpenCode => {
+            let id = required_session_id(session_id, "opencode")?;
+            let schema = opencode::schema_of(path, id)?;
+            Ok((path.to_path_buf(), opencode::messages_for_session(path, id, schema, pick)?))
+        }
+    }
+}
+
+pub(super) fn exact(
+    host: Host,
+    session_id: &str,
+    exact: ExactSession,
+    pick: usize,
+) -> Result<(PathBuf, Vec<Message>)> {
+    match (host, exact) {
+        (Host::ClaudeCode, ExactSession::File(path)) => {
+            let messages = claude_messages(&path, pick)?;
+            Ok((path, messages))
+        }
+        (Host::Codex, ExactSession::Codex(files)) => codex_files(&files, session_id, pick),
+        (Host::Copilot, ExactSession::File(path)) => {
+            let messages = copilot_messages(&path, pick)?;
+            Ok((path, messages))
+        }
+        (Host::Droid, ExactSession::File(path)) => {
+            let messages = droid_messages(&path, pick)?;
+            Ok((path, messages))
+        }
+        (Host::Pi, ExactSession::File(path)) => {
+            let messages = pi_messages(&path, pick)?;
+            Ok((path, messages))
+        }
+        (Host::Omp, ExactSession::File(path)) => {
+            let messages = omp_messages(&path, pick)?;
+            Ok((path, messages))
+        }
+        (Host::Hermes, ExactSession::Hermes(database)) => {
+            let messages = hermes::messages_for_session(&database, session_id, pick)?;
+            Ok((database, messages))
+        }
+        (Host::OpenCode, ExactSession::OpenCode { database, schema }) => {
+            let messages = opencode::messages_for_session(&database, session_id, schema, pick)?;
+            Ok((database, messages))
+        }
+        _ => bail!("internal error: exact session kind does not match {}", host.label()),
+    }
+}
+
+fn required_session_id<'a>(session_id: Option<&'a str>, host: &str) -> Result<&'a str> {
+    let Some(id) = session_id else {
+        bail!("{host} needs a session id (Herdr provides it; or pass --session-id)");
+    };
+    Ok(plannotator_tui_hosts::validate_session_id(id)?)
+}
+
+pub(super) fn claude_messages(path: &Path, pick: usize) -> Result<Vec<Message>> {
+    let text = std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    Ok(claude::parse_messages(&text, pick))
+}
+
+pub(super) fn codex_thread(
+    codex_home: &Path,
+    thread: Option<&str>,
+    pick: usize,
+) -> Result<(PathBuf, Vec<Message>)> {
+    let files = codex::find_transcripts(codex_home, thread);
+    let Some(newest) = files.last().cloned() else {
+        bail!(
+            "no Codex transcript under {} (thread {})",
+            codex_home.join("sessions").display(),
+            thread.unwrap_or("newest")
+        );
+    };
+    let messages = codex_messages(&files, pick)?;
+    Ok((newest, messages))
+}
+
+fn codex_files(files: &[PathBuf], thread: &str, pick: usize) -> Result<(PathBuf, Vec<Message>)> {
+    let Some(newest) = files.last().cloned() else {
+        bail!("no Codex transcript for thread {thread}");
+    };
+    let messages = codex_messages(files, pick)?;
+    Ok((newest, messages))
+}
+
+fn codex_messages(files: &[PathBuf], pick: usize) -> Result<Vec<Message>> {
+    let contents = files
+        .iter()
+        .map(|path| std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display())))
+        .collect::<Result<Vec<String>>>()?;
+    Ok(codex::parse_messages(&contents, pick))
+}
+
+pub(super) fn copilot_messages(dir: &Path, pick: usize) -> Result<Vec<Message>> {
+    let events = dir.join("events.jsonl");
+    let text = std::fs::read_to_string(&events).with_context(|| format!("reading {}", events.display()))?;
+    Ok(copilot::parse_messages(&text, pick))
+}
+
+pub(super) fn droid_messages(path: &Path, pick: usize) -> Result<Vec<Message>> {
+    let text = std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    Ok(droid::parse_messages(&text, pick))
+}
+
+pub(super) fn omp_messages(path: &Path, pick: usize) -> Result<Vec<Message>> {
+    let text = std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    Ok(omp::parse_messages(&text, pick))
+}
+
+pub(super) fn pi_messages(path: &Path, pick: usize) -> Result<Vec<Message>> {
+    let text = std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    Ok(pi::parse_messages(&text, pick))
+}

--- a/crates/plannotator-tui/src/last/roots.rs
+++ b/crates/plannotator-tui/src/last/roots.rs
@@ -1,0 +1,143 @@
+//! Host storage roots derived from the process environment.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+use plannotator_tui_hosts::{hermes, opencode};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Roots {
+    pub(super) home: PathBuf,
+    pub(super) claude_config: PathBuf,
+    pub(super) codex_home: PathBuf,
+    pub(super) copilot_home: PathBuf,
+    pub(super) factory_config: PathBuf,
+    pi_session_dir: Option<PathBuf>,
+    pi_agent_dir: Option<PathBuf>,
+    hermes_home: PathBuf,
+    opencode_db: Option<PathBuf>,
+    xdg_data_home: PathBuf,
+}
+
+impl Roots {
+    pub(super) fn from_env() -> Self {
+        let home = std::env::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+        Self::from_lookup(home, |key| std::env::var_os(key))
+    }
+
+    fn from_lookup(home: PathBuf, env: impl Fn(&str) -> Option<OsString>) -> Self {
+        let path = |key: &str| env(key).filter(|value| !value.is_empty()).map(PathBuf::from);
+        let hermes_home = path("HERMES_HOME").unwrap_or_else(|| default_hermes_home(&home, &env));
+        let xdg_data_home = path("XDG_DATA_HOME").unwrap_or_else(|| home.join(".local").join("share"));
+        Self {
+            claude_config: path("CLAUDE_CONFIG_DIR").unwrap_or_else(|| home.join(".claude")),
+            codex_home: path("CODEX_HOME").unwrap_or_else(|| home.join(".codex")),
+            copilot_home: path("COPILOT_HOME").unwrap_or_else(|| home.join(".copilot")),
+            factory_config: path("FACTORY_CONFIG_DIR").unwrap_or_else(|| home.join(".factory")),
+            pi_session_dir: path("PI_CODING_AGENT_SESSION_DIR"),
+            pi_agent_dir: path("PI_CODING_AGENT_DIR"),
+            hermes_home,
+            opencode_db: path("OPENCODE_DB"),
+            xdg_data_home,
+            home,
+        }
+    }
+
+    pub(super) fn pi_sessions(&self, default_agent_dir: &str) -> PathBuf {
+        self.pi_session_dir.clone().unwrap_or_else(|| {
+            self.pi_agent_dir.clone().unwrap_or_else(|| self.home.join(default_agent_dir)).join("sessions")
+        })
+    }
+
+    pub(super) fn hermes_database(&self) -> PathBuf {
+        self.hermes_home.join(hermes::DB_FILE)
+    }
+
+    pub(super) fn opencode_databases(&self) -> Vec<PathBuf> {
+        if let Some(db) = &self.opencode_db {
+            return vec![db.clone()];
+        }
+        let data = self.xdg_data_home.join(opencode::DATA_DIR);
+        let mut found: Vec<PathBuf> = std::fs::read_dir(&data)
+            .map(|entries| {
+                entries
+                    .filter_map(Result::ok)
+                    .map(|entry| entry.path())
+                    .filter(|path| {
+                        path.file_name().and_then(|name| name.to_str()).is_some_and(|name| {
+                            name.starts_with("opencode") && name.to_ascii_lowercase().ends_with(".db")
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        found.sort();
+        if found.is_empty() {
+            found.push(data.join(opencode::DB_FILE));
+        }
+        found
+    }
+}
+
+#[cfg(windows)]
+fn default_hermes_home(home: &std::path::Path, env: &impl Fn(&str) -> Option<OsString>) -> PathBuf {
+    env("LOCALAPPDATA")
+        .filter(|value| !value.is_empty())
+        .map_or_else(|| home.join("AppData").join("Local"), PathBuf::from)
+        .join("hermes")
+}
+
+#[cfg(not(windows))]
+fn default_hermes_home(home: &std::path::Path, _env: &impl Fn(&str) -> Option<OsString>) -> PathBuf {
+    home.join(".hermes")
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, reason = "tests assert by panicking")]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn every_documented_root_override_is_honoured() {
+        let values: HashMap<&str, OsString> = [
+            ("CLAUDE_CONFIG_DIR", "root/claude".into()),
+            ("CODEX_HOME", "root/codex".into()),
+            ("COPILOT_HOME", "root/copilot".into()),
+            ("FACTORY_CONFIG_DIR", "root/factory".into()),
+            ("PI_CODING_AGENT_SESSION_DIR", "root/pi sessions".into()),
+            ("PI_CODING_AGENT_DIR", "root/pi agent ignored".into()),
+            ("HERMES_HOME", "root/hermes".into()),
+            ("OPENCODE_DB", "root/opencode/custom.db".into()),
+            ("XDG_DATA_HOME", "root/xdg ignored".into()),
+        ]
+        .into_iter()
+        .collect();
+        let roots = Roots::from_lookup(PathBuf::from("home"), |key| values.get(key).cloned());
+        assert_eq!(roots.claude_config, PathBuf::from("root/claude"));
+        assert_eq!(roots.codex_home, PathBuf::from("root/codex"));
+        assert_eq!(roots.copilot_home, PathBuf::from("root/copilot"));
+        assert_eq!(roots.factory_config, PathBuf::from("root/factory"));
+        assert_eq!(roots.pi_sessions(".pi/agent"), PathBuf::from("root/pi sessions"));
+        assert_eq!(roots.hermes_database(), PathBuf::from("root/hermes").join(hermes::DB_FILE));
+        assert_eq!(roots.opencode_databases(), vec![PathBuf::from("root/opencode/custom.db")]);
+    }
+
+    #[test]
+    fn pi_agent_and_xdg_overrides_apply_when_the_more_specific_values_are_absent() {
+        let values: HashMap<&str, OsString> =
+            [("PI_CODING_AGENT_DIR", "root/pi agent ü".into()), ("XDG_DATA_HOME", "root/data ü".into())]
+                .into_iter()
+                .collect();
+        let roots = Roots::from_lookup(PathBuf::from("home"), |key| values.get(key).cloned());
+        assert_eq!(
+            roots.pi_sessions(plannotator_tui_hosts::omp::DEFAULT_AGENT_DIR),
+            PathBuf::from("root/pi agent ü/sessions")
+        );
+        assert_eq!(
+            roots.opencode_databases(),
+            vec![PathBuf::from("root/data ü").join(opencode::DATA_DIR).join(opencode::DB_FILE)]
+        );
+    }
+}

--- a/crates/plannotator-tui/tests/last.rs
+++ b/crates/plannotator-tui/tests/last.rs
@@ -7,12 +7,35 @@ use std::process::Command;
 
 use plannotator_tui_hosts::{Role, claude, codex, copilot, droid, omp, pi};
 
+const NAMED_CODEX_ID: &str = "11111111-1111-4111-8111-111111111111";
+const NEWER_CODEX_ID: &str = "22222222-2222-4222-8222-222222222222";
+
 fn bin() -> Command {
     Command::new(env!("CARGO_BIN_EXE_plannotator-tui"))
 }
 
 fn fixtures() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../plannotator-tui-hosts/tests/fixtures")
+}
+
+fn temp_dir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("plannotator last {tag} ü-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    dir
+}
+
+fn codex_rollout(home: &std::path::Path, day: &str, time: &str, id: &str, text: &str) {
+    let file =
+        home.join("sessions/2026/08").join(day).join(format!("rollout-2026-08-{day}T{time}-{id}.jsonl"));
+    std::fs::create_dir_all(file.parent().expect("parent")).expect("sessions");
+    std::fs::write(
+        file,
+        format!(
+            "{{\"timestamp\":\"2026-08-{day}T{time}Z\",\"type\":\"event_msg\",\"payload\":{{\"type\":\"task_started\"}}}}\n{{\"timestamp\":\"2026-08-{day}T{time}Z\",\"type\":\"response_item\",\"payload\":{{\"type\":\"message\",\"role\":\"assistant\",\"id\":\"m-{id}\",\"content\":[{{\"type\":\"output_text\",\"text\":\"{text}\"}}]}}}}\n"
+        ),
+    )
+    .expect("rollout");
 }
 
 #[test]
@@ -47,6 +70,63 @@ fn print_reads_a_codex_thread_from_a_sessions_root() {
         .expect("runs");
     assert!(out.status.success());
     assert_eq!(String::from_utf8_lossy(&out.stdout).trim_end(), expected.trim_end());
+}
+
+#[test]
+fn herdr_reported_codex_id_beats_a_newer_unrelated_rollout() {
+    let root = temp_dir("codex id");
+    let home = root.join("codex home");
+    codex_rollout(&home, "30", "10-00-00", NAMED_CODEX_ID, "NAMED SESSION");
+    codex_rollout(&home, "31", "10-00-00", NEWER_CODEX_ID, "NEWER UNRELATED SESSION");
+    let out = bin()
+        .env("CODEX_HOME", &home)
+        .env_remove("CODEX_THREAD_ID")
+        .args(["last", "--host", "codex", "--session-id", NAMED_CODEX_ID, "--print"])
+        .output()
+        .expect("runs");
+    assert!(out.status.success());
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "NAMED SESSION");
+    assert!(out.stderr.is_empty(), "{}", String::from_utf8_lossy(&out.stderr));
+
+    let miss = bin()
+        .env("CODEX_HOME", &home)
+        .env_remove("CODEX_THREAD_ID")
+        .args(["last", "--host", "codex", "--session-id", "missing", "--print"])
+        .output()
+        .expect("runs");
+    assert!(miss.status.success(), "--print keeps its exit-zero contract");
+    assert!(miss.stdout.is_empty(), "an exact miss must not print the newer session");
+    let stderr = String::from_utf8_lossy(&miss.stderr);
+    assert!(stderr.contains("no Codex session missing"), "{stderr}");
+    assert!(stderr.contains(&home.join("sessions").display().to_string()), "{stderr}");
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+fn claude_config_override_is_used_for_an_exact_id() {
+    let root = temp_dir("claude override");
+    let config = root.join("Claude Config ü");
+    let cwd = root.join("work tree");
+    let transcript = config.join("projects").join(claude::project_slug(&cwd)).join("claude-exact.jsonl");
+    std::fs::create_dir_all(transcript.parent().expect("parent")).expect("project");
+    std::fs::copy(fixtures().join("claude-code.jsonl"), &transcript).expect("fixture copy");
+    let text = std::fs::read_to_string(&transcript).expect("fixture");
+    let expected = claude::parse_messages(&text, 25)
+        .into_iter()
+        .find(|message| message.role == Role::Assistant)
+        .expect("assistant")
+        .text;
+    std::fs::create_dir_all(&cwd).expect("cwd");
+    let out = bin()
+        .current_dir(&cwd)
+        .env("CLAUDE_CONFIG_DIR", &config)
+        .env("PLANNOTATOR_TUI_CWD", &cwd)
+        .args(["last", "--host", "claude", "--session-id", "claude-exact", "--print"])
+        .output()
+        .expect("runs");
+    assert!(out.status.success());
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim_end(), expected.trim_end());
+    std::fs::remove_dir_all(root).expect("cleanup");
 }
 
 #[test]

--- a/crates/plannotator-tui/tests/support/fake-herdr.rs
+++ b/crates/plannotator-tui/tests/support/fake-herdr.rs
@@ -1,0 +1,72 @@
+//! Standalone argv recorder compiled by Windows tests with `rustc`.
+
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::path::Path;
+
+fn json_string(value: &str) -> String {
+    let mut out = String::from("\"");
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            ch if ch.is_control() => out.push_str(&format!("\\u{:04x}", ch as u32)),
+            ch => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn fixture(root: &Path, name: &str, fallback: &str) -> String {
+    std::fs::read_to_string(root.join(name)).unwrap_or_else(|_| fallback.to_owned())
+}
+
+fn main() {
+    let executable = std::env::current_exe().unwrap_or_default();
+    let root = executable.parent().unwrap_or_else(|| Path::new("."));
+    let program = executable
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("unknown");
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let json_args = args
+        .iter()
+        .map(|arg| json_string(arg))
+        .collect::<Vec<_>>()
+        .join(",");
+    let line = format!(
+        "{{\"program\":{},\"argv\":[{}]}}\n",
+        json_string(program),
+        json_args
+    );
+    let mut log = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(root.join("calls.jsonl"))
+        .expect("open call log");
+    log.write_all(line.as_bytes()).expect("write call log");
+
+    match args.iter().map(String::as_str).collect::<Vec<_>>().as_slice() {
+        ["agent", "get", _] => print!(
+            "{}",
+            fixture(
+                root,
+                "agent-get.json",
+                r#"{"result":{"agent":{"agent":"codex","agent_session":{"kind":"id","value":"11111111-1111-4111-8111-111111111111"}}}}"#,
+            )
+        ),
+        ["pane", "process-info", ..] => print!(
+            "{}",
+            fixture(
+                root,
+                "process-info.json",
+                r#"{"result":{"process_info":{"foreground_process_group_id":42,"foreground_processes":[{"name":"codex","pid":42}]}}}"#,
+            )
+        ),
+        _ => print!(r#"{{"result":{{}}}}"#),
+    }
+}

--- a/crates/plannotator-tui/tests/windows_subprocess.rs
+++ b/crates/plannotator-tui/tests/windows_subprocess.rs
@@ -49,7 +49,7 @@ fn calls(fake: &Path) -> Vec<Value> {
         .collect()
 }
 
-fn context(cwd: &Path, clicked_url: Option<String>) -> String {
+fn context(cwd: &Path, clicked_url: Option<&str>) -> String {
     json!({
         "focused_pane_id": "w1:p1",
         "focused_pane_agent": "codex",
@@ -77,13 +77,14 @@ fn clicked_file_and_exact_session_launches_preserve_argv_without_process_info() 
     std::fs::write(&clicked, "# plan\n").expect("clicked file");
     let plugin_root = root.join("plugin root with spaces ü");
     std::fs::create_dir_all(&plugin_root).expect("plugin root");
+    let clicked_url = file_url(&clicked);
 
     let open = bin()
         .env("HERDR_ENV", "1")
         .env("HERDR_BIN_PATH", &fake)
         .env("HERDR_PLUGIN_ID", "annotate")
         .env("HERDR_PLUGIN_ROOT", &plugin_root)
-        .env("HERDR_PLUGIN_CONTEXT_JSON", context(&clicked_root, Some(file_url(&clicked))))
+        .env("HERDR_PLUGIN_CONTEXT_JSON", context(&clicked_root, Some(&clicked_url)))
         .args(["herdr", "open"])
         .output()
         .expect("open launcher");

--- a/crates/plannotator-tui/tests/windows_subprocess.rs
+++ b/crates/plannotator-tui/tests/windows_subprocess.rs
@@ -1,0 +1,214 @@
+//! Native Windows proof that Herdr commands cross `CreateProcess` as separate argv values.
+
+#![cfg(windows)]
+#![allow(clippy::expect_used, clippy::indexing_slicing, reason = "tests assert by panicking")]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::{Value, json};
+
+const SESSION_ID: &str = "11111111-1111-4111-8111-111111111111";
+const NEWER_ID: &str = "22222222-2222-4222-8222-222222222222";
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_plannotator-tui"))
+}
+
+fn temp_root(tag: &str) -> PathBuf {
+    let base = std::env::var_os("RUNNER_TEMP").map_or_else(std::env::temp_dir, PathBuf::from);
+    let root = base.join(format!("plannotator Windows {tag} ü-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).expect("temp root");
+    root
+}
+
+fn compile_fake(root: &Path) -> PathBuf {
+    let dir = root.join("fake herdr");
+    std::fs::create_dir_all(&dir).expect("fake dir");
+    let executable = dir.join("herdr.exe");
+    let source = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/support/fake-herdr.rs");
+    let output = Command::new("rustc")
+        .arg("--edition=2024")
+        .arg(&source)
+        .arg("-o")
+        .arg(&executable)
+        .output()
+        .expect("run rustc");
+    assert!(output.status.success(), "rustc failed: {}", String::from_utf8_lossy(&output.stderr));
+    std::fs::copy(&executable, dir.join("ps.exe")).expect("ps recorder");
+    executable
+}
+
+fn calls(fake: &Path) -> Vec<Value> {
+    let log = fake.parent().expect("fake dir").join("calls.jsonl");
+    std::fs::read_to_string(log)
+        .expect("call log")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("JSON call"))
+        .collect()
+}
+
+fn context(cwd: &Path, clicked_url: Option<String>) -> String {
+    json!({
+        "focused_pane_id": "w1:p1",
+        "focused_pane_agent": "codex",
+        "focused_pane_cwd": cwd,
+        "workspace_cwd": cwd,
+        "clicked_url": clicked_url,
+    })
+    .to_string()
+}
+
+fn file_url(path: &Path) -> String {
+    format!("file:///{}", path.display().to_string().replace('\\', "/").replace(' ', "%20"))
+}
+
+#[test]
+fn clicked_file_and_exact_session_launches_preserve_argv_without_process_info() {
+    let root = temp_root("launcher");
+    let fake = compile_fake(&root);
+    let system_drive = std::env::var("SystemDrive").unwrap_or_else(|_| "C:".to_owned());
+    let clicked_root =
+        PathBuf::from(format!(r"{system_drive}\plannotator clicked proof ü-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&clicked_root);
+    std::fs::create_dir_all(&clicked_root).expect("clicked root");
+    let clicked = clicked_root.join("plan with spaces.md");
+    std::fs::write(&clicked, "# plan\n").expect("clicked file");
+    let plugin_root = root.join("plugin root with spaces ü");
+    std::fs::create_dir_all(&plugin_root).expect("plugin root");
+
+    let open = bin()
+        .env("HERDR_ENV", "1")
+        .env("HERDR_BIN_PATH", &fake)
+        .env("HERDR_PLUGIN_ID", "annotate")
+        .env("HERDR_PLUGIN_ROOT", &plugin_root)
+        .env("HERDR_PLUGIN_CONTEXT_JSON", context(&clicked_root, Some(file_url(&clicked))))
+        .args(["herdr", "open"])
+        .output()
+        .expect("open launcher");
+    assert!(open.status.success(), "{}", String::from_utf8_lossy(&open.stderr));
+
+    let last = bin()
+        .env("HERDR_ENV", "1")
+        .env("HERDR_BIN_PATH", &fake)
+        .env("HERDR_PLUGIN_ID", "annotate")
+        .env("HERDR_PLUGIN_ROOT", &plugin_root)
+        .env("HERDR_PLUGIN_CONTEXT_JSON", context(&clicked_root, None))
+        .args(["herdr", "last"])
+        .output()
+        .expect("last launcher");
+    assert!(last.status.success(), "{}", String::from_utf8_lossy(&last.stderr));
+
+    let calls = calls(&fake);
+    assert_eq!(
+        calls[0]["argv"],
+        json!([
+            "plugin",
+            "pane",
+            "open",
+            "--plugin",
+            "annotate",
+            "--entrypoint",
+            "doc",
+            "--placement",
+            "overlay",
+            "--focus",
+            "--cwd",
+            clicked_root.display().to_string(),
+            "--env",
+            format!("PLANNOTATOR_TUI_FILE={}", clicked.display()),
+            "--env",
+            "PLANNOTATOR_TUI_DELIVER_TO=w1:p1",
+            "--env",
+            "PLANNOTATOR_TUI_DELIVER_AGENT=codex",
+        ])
+    );
+    assert_eq!(calls[1]["argv"], json!(["agent", "get", "w1:p1"]));
+    assert_eq!(
+        calls[2]["argv"],
+        json!([
+            "plugin",
+            "pane",
+            "open",
+            "--plugin",
+            "annotate",
+            "--entrypoint",
+            "doc",
+            "--placement",
+            "overlay",
+            "--focus",
+            "--cwd",
+            clicked_root.display().to_string(),
+            "--env",
+            "PLANNOTATOR_TUI_HOST=codex",
+            "--env",
+            format!("PLANNOTATOR_TUI_CWD={}", clicked_root.display()),
+            "--env",
+            format!("PLANNOTATOR_TUI_SESSION_ID={SESSION_ID}"),
+            "--env",
+            "PLANNOTATOR_TUI_DELIVER_TO=w1:p1",
+            "--env",
+            "PLANNOTATOR_TUI_DELIVER_AGENT=codex",
+        ])
+    );
+    assert!(
+        calls.iter().all(|call| {
+            call["argv"].as_array().is_none_or(|args| !args.iter().any(|arg| arg == "process-info"))
+        }),
+        "exact identity must not call pane process-info: {calls:?}"
+    );
+    assert!(
+        calls[2]["argv"]
+            .as_array()
+            .expect("argv")
+            .iter()
+            .all(|arg| !arg.as_str().is_some_and(|arg| arg.starts_with("PLANNOTATOR_TUI_MESSAGE_PID=")))
+    );
+
+    std::fs::remove_dir_all(clicked_root).expect("clicked cleanup");
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+fn codex_rollout(home: &Path, day: &str, id: &str, text: &str) {
+    let file =
+        home.join("sessions/2026/08").join(day).join(format!("rollout-2026-08-{day}T10-00-00-{id}.jsonl"));
+    std::fs::create_dir_all(file.parent().expect("parent")).expect("sessions");
+    std::fs::write(
+        file,
+        format!(
+            "{{\"timestamp\":\"2026-08-{day}T10:00:00Z\",\"type\":\"event_msg\",\"payload\":{{\"type\":\"task_started\"}}}}\n{{\"timestamp\":\"2026-08-{day}T10:00:00Z\",\"type\":\"response_item\",\"payload\":{{\"type\":\"message\",\"role\":\"assistant\",\"id\":\"m-{id}\",\"content\":[{{\"type\":\"output_text\",\"text\":\"{text}\"}}]}}}}\n"
+        ),
+    )
+    .expect("rollout");
+}
+
+#[test]
+fn exact_print_uses_the_named_rollout_and_never_attempts_ps() {
+    let root = temp_root("last print");
+    let fake = compile_fake(&root);
+    let home = root.join("Codex Home ü");
+    codex_rollout(&home, "30", SESSION_ID, "NAMED WINDOWS SESSION");
+    codex_rollout(&home, "31", NEWER_ID, "NEWER UNRELATED SESSION");
+    let fake_dir = fake.parent().expect("fake dir");
+    let inherited_path = std::env::var_os("PATH").unwrap_or_default();
+    let search_path = std::env::join_paths(
+        std::iter::once(fake_dir.to_path_buf()).chain(std::env::split_paths(&inherited_path)),
+    )
+    .expect("PATH");
+    let output = bin()
+        .env("CODEX_HOME", &home)
+        .env("PATH", search_path)
+        .env_remove("CODEX_THREAD_ID")
+        .args(["last", "--host", "codex", "--session-id", SESSION_ID, "--print"])
+        .output()
+        .expect("last print");
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "NAMED WINDOWS SESSION");
+    let log = fake_dir.join("calls.jsonl");
+    if log.exists() {
+        let calls = calls(&fake);
+        assert!(calls.iter().all(|call| call["program"] != "ps"), "exact last attempted ps: {calls:?}");
+    }
+    std::fs::remove_dir_all(root).expect("cleanup");
+}

--- a/crates/plannotator-tui/tests/windows_subprocess.rs
+++ b/crates/plannotator-tui/tests/windows_subprocess.rs
@@ -78,6 +78,8 @@ fn clicked_file_and_exact_session_launches_preserve_argv_without_process_info() 
     let plugin_root = root.join("plugin root with spaces ü");
     std::fs::create_dir_all(&plugin_root).expect("plugin root");
     let clicked_url = file_url(&clicked);
+    let clicked_root_from_url = clicked_root.display().to_string().replace('\\', "/");
+    let clicked_from_url = clicked.display().to_string().replace('\\', "/");
 
     let open = bin()
         .env("HERDR_ENV", "1")
@@ -116,9 +118,9 @@ fn clicked_file_and_exact_session_launches_preserve_argv_without_process_info() 
             "overlay",
             "--focus",
             "--cwd",
-            clicked_root.display().to_string(),
+            clicked_root_from_url,
             "--env",
-            format!("PLANNOTATOR_TUI_FILE={}", clicked.display()),
+            format!("PLANNOTATOR_TUI_FILE={clicked_from_url}"),
             "--env",
             "PLANNOTATOR_TUI_DELIVER_TO=w1:p1",
             "--env",


### PR DESCRIPTION
## Summary

Implements `docs/spec-windows-full.md` ordered plan steps 1–3 only.

- freezes session selection at path → id → pid metadata → cwd/mtime for every supported host
- validates exact IDs before store access, honors the specified root overrides, and errors on exact misses without selecting another session
- makes `herdr agent get` authoritative when it supplies a supported host and session reference, so exact launches do not call `pane process-info` or set a message PID
- cfg-gates POSIX process probes and makes unsupported Windows/OMP heuristic paths explicit
- adds generated Windows-path resolver coverage, current OpenCode schema coverage, and the Codex exact-ID regression characterization without modifying existing macOS/Linux fixtures
- adds a native Windows `fake-herdr.exe` subprocess proof for file URLs, argv boundaries, exact-ID launch ordering, feedback metacharacters, and absence of `process-info`/`ps`
- upgrades the pull-request Windows job to the spec's exact five-command gate and pins Rust source checkout to the Unix newline style required by `rustfmt.toml`

## Local validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --all-targets`
- `cargo build --release -p plannotator-tui`
- `./target/release/plannotator-tui --version`
- `git diff --check`

All passed on macOS. Native `CreateProcess` behavior and Windows-only test bodies are intentionally proved by this PR's `windows-latest` job.

## Scope boundary

This PR contains spec steps 1–3 only. Step 4 (`aarch64-pc-windows-msvc`) is deferred until this PR is merged by the maintainer; this PR makes no Windows ARM64 support claim. Installer and manifest steps 5–8 and the live-host matrix are out of scope.

Architect review is required. The implementation agent must not merge this PR.

## Commits

- `feat(last): resolve exact agent sessions`
- `test(windows): prove herdr argv boundaries`
- `ci: run the full windows pull-request suite`
- `ci: preserve unix rust source newlines`
