### PR TITLE
windows arm64 release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
           - { target: x86_64-apple-darwin,       os: macos-15-intel }
           - { target: aarch64-apple-darwin,      os: macos-15 }
           - { target: x86_64-pc-windows-msvc,    os: windows-latest }
+          - { target: aarch64-pc-windows-msvc,   os: windows-latest }
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     steps:


### PR DESCRIPTION
## Summary

- add `aarch64-pc-windows-msvc` to the Windows release cross-build matrix
- retain target-derived naming so the published artifact is `plannotator-tui-aarch64-pc-windows-msvc.exe` and is included in `SHA256SUMS`

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- [`windows-latest` cross-build probe](https://github.com/plannotator/plannotator-tui/actions/runs/33349938871/job/99361172332): `cargo build --release -p plannotator-tui --target aarch64-pc-windows-msvc`

## Scope

Cross-build only. Native execution is outside this PR.