### PR TITLE
release: 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,7 @@ checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plannotator-tui"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "plannotator-tui-hosts",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "plannotator-tui-hosts"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "rusqlite",
  "serde_json",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "plannotator-tui-schema"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "jsonschema",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/plannotator-tui-schema", "crates/plannotator-tui-hosts", "crates/plannotator-tui"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/crates/plannotator-tui/Cargo.toml
+++ b/crates/plannotator-tui/Cargo.toml
@@ -14,8 +14,8 @@ name = "plannotator-tui"
 path = "src/main.rs"
 
 [dependencies]
-plannotator-tui-schema = { path = "../plannotator-tui-schema", version = "0.5.0" }
-plannotator-tui-hosts = { path = "../plannotator-tui-hosts", version = "0.5.0" }
+plannotator-tui-schema = { path = "../plannotator-tui-schema", version = "0.6.0" }
+plannotator-tui-hosts = { path = "../plannotator-tui-hosts", version = "0.6.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Version bump for 0.6.0.

Ships since 0.5.0:
- exact session resolution: Herdr-reported session paths/ids are authoritative for every host; exact misses error instead of opening a different session (#48)
- Windows x64 test gate on pull requests and native Windows subprocess proof (#48)
- Windows ARM64 release asset (#49)
- Windows Full-mode support spec (#46)
- README screenshot shows the agent send label (#47)

https://claude.ai/code/session_01L232F8ev8RX6Jwd7PepsUz