### PR TITLE
fix(last): resolve Codex transcripts from the selected Linux process

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ reads a document;
 `--print` writes the newest reply to stdout and always exits 0 (for hooks and scripts).
 Reply reviews are never written to disk.
 
+On Linux, an explicit Codex `--pid` selects the rollout opened by that process. If it
+cannot be identified uniquely, `last` reports the failure instead of choosing an unrelated
+session. `--session` and `--session-id` keep precedence over PID discovery.
+
 ## Where annotations live
 
 ```

--- a/crates/plannotator-tui-hosts/src/codex.rs
+++ b/crates/plannotator-tui-hosts/src/codex.rs
@@ -51,8 +51,10 @@ fn thread_of(path: &Path) -> Option<String> {
     (parts.len() == 6).then(|| parts.iter().take(5).rev().copied().collect::<Vec<_>>().join("-"))
 }
 
-/// Subagent rollouts (reviews, guardians) record `source.subagent` in their session meta.
-fn is_subagent(path: &Path) -> bool {
+/// Does `path` hold a subagent rollout? Subagent rollouts (reviews, guardians) record
+/// `source.subagent` in the session meta on their first line. Unreadable or malformed
+/// files are not subagents.
+pub fn is_subagent(path: &Path) -> bool {
     let Ok(text) = std::fs::read_to_string(path) else { return false };
     text.lines()
         .next()

--- a/crates/plannotator-tui/src/last/fallback.rs
+++ b/crates/plannotator-tui/src/last/fallback.rs
@@ -61,6 +61,7 @@ pub(super) fn read(
 
 /// A selected Linux process is a stronger hint than an inherited thread id or the newest
 /// rollout. Missing or ambiguous descriptors must not silently select another session.
+/// Codex keeps its subagents' rollouts (reviews, guardians) open too; those are ignored.
 #[cfg(target_os = "linux")]
 fn find_codex_transcript(pid: u32) -> Result<PathBuf> {
     let directory = PathBuf::from(format!("/proc/{pid}/fd"));
@@ -77,6 +78,7 @@ fn find_codex_transcript(pid: u32) -> Result<PathBuf> {
                 .and_then(|name| name.to_str())
                 .is_some_and(|name| name.starts_with("rollout-"))
             && path.is_file()
+            && !plannotator_tui_hosts::codex::is_subagent(&path)
         {
             transcripts.insert(path);
         }

--- a/crates/plannotator-tui/src/last/fallback.rs
+++ b/crates/plannotator-tui/src/last/fallback.rs
@@ -28,6 +28,11 @@ pub(super) fn read(
             Ok((path, messages))
         }
         Host::Codex => {
+            #[cfg(target_os = "linux")]
+            if let Some(pid) = options.pid {
+                let path = find_codex_transcript(pid)?;
+                return readers::explicit(host, &path, None, pick);
+            }
             let thread = std::env::var("CODEX_THREAD_ID").ok().filter(|thread| !thread.is_empty());
             readers::codex_thread(&roots.codex_home, thread.as_deref(), pick)
         }
@@ -52,6 +57,37 @@ pub(super) fn read(
         Host::Hermes => bail!("hermes needs a session id (Herdr provides it; or pass --session-id)"),
         Host::OpenCode => opencode_for_cwd(cwd, roots, pick),
     }
+}
+
+/// A selected Linux process is a stronger hint than an inherited thread id or the newest
+/// rollout. Missing or ambiguous descriptors must not silently select another session.
+#[cfg(target_os = "linux")]
+fn find_codex_transcript(pid: u32) -> Result<PathBuf> {
+    let directory = PathBuf::from(format!("/proc/{pid}/fd"));
+    let entries = std::fs::read_dir(&directory)
+        .with_context(|| format!("reading Codex process {pid} descriptors in {}", directory.display()))?;
+    let mut transcripts = std::collections::BTreeSet::new();
+    for entry in entries {
+        let entry = entry.with_context(|| format!("reading {}", directory.display()))?;
+        // Descriptors can close between readdir and readlink.
+        let Ok(path) = std::fs::read_link(entry.path()) else { continue };
+        if path.extension().is_some_and(|extension| extension == "jsonl")
+            && path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("rollout-"))
+            && path.is_file()
+        {
+            transcripts.insert(path);
+        }
+    }
+    if transcripts.len() != 1 {
+        bail!(
+            "Codex process {pid} has {} open transcripts; pass --session or --session-id to select one",
+            transcripts.len()
+        );
+    }
+    transcripts.into_iter().next().with_context(|| format!("no transcript for Codex process {pid}"))
 }
 
 fn find_claude_transcript(pid: Option<u32>, cwd: &Path, roots: &Roots) -> Result<PathBuf> {

--- a/crates/plannotator-tui/tests/codex_pid.rs
+++ b/crates/plannotator-tui/tests/codex_pid.rs
@@ -1,0 +1,136 @@
+//! Linux PID discovery through the CLI, with real open transcript descriptors.
+
+#![cfg(target_os = "linux")]
+#![allow(clippy::expect_used, reason = "tests assert by panicking")]
+
+use std::io::{BufRead as _, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+const SELECTED_ID: &str = "11111111-1111-4111-8111-111111111111";
+const OTHER_ID: &str = "22222222-2222-4222-8222-222222222222";
+
+#[derive(Debug)]
+struct Fixture {
+    directory: PathBuf,
+    selected: PathBuf,
+    other: PathBuf,
+}
+
+impl Fixture {
+    fn new(tag: &str) -> Self {
+        let directory =
+            std::env::temp_dir().join(format!("plannotator codex pid {tag} ü-{}", std::process::id()));
+        std::fs::create_dir_all(&directory).expect("fixture directory");
+        let selected = Self::rollout(&directory, "01", SELECTED_ID, "SELECTED PANE");
+        let other = Self::rollout(&directory, "02", OTHER_ID, "OTHER PANE");
+        Self { directory, selected, other }
+    }
+
+    fn rollout(directory: &Path, day: &str, id: &str, text: &str) -> PathBuf {
+        let path =
+            directory.join(format!("sessions/2026/09/{day}/rollout-2026-09-{day}T01-00-00-{id}.jsonl"));
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("session directory");
+        let message = serde_json::json!({
+            "type": "response_item",
+            "payload": {"type": "message", "role": "assistant", "id": id,
+                        "content": [{"type": "output_text", "text": text}]}
+        });
+        std::fs::write(&path, format!("{message}\n")).expect("transcript");
+        path
+    }
+
+    fn command(&self, pid: u32) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_plannotator-tui"));
+        command
+            .env("CODEX_HOME", &self.directory)
+            // An inherited id from another pane must not override the explicitly selected PID.
+            .env("CODEX_THREAD_ID", OTHER_ID)
+            .args(["last", "--host", "codex", "--pid", &pid.to_string(), "--print"]);
+        command
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.directory);
+    }
+}
+
+#[derive(Debug)]
+struct HoldingProcess(Child);
+
+impl HoldingProcess {
+    fn new(first: &Path, second: Option<&Path>) -> Self {
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            "exec 3<\"$1\"; if [ -n \"${2:-}\" ]; then exec 4<\"$2\"; fi; printf 'ready\\n'; read -r line",
+            "hold-transcripts",
+        ]).arg(first);
+        if let Some(path) = second {
+            command.arg(path);
+        }
+        let mut process = Self(command.stdin(Stdio::piped()).stdout(Stdio::piped()).spawn().expect("holder"));
+        let mut ready = String::new();
+        BufReader::new(process.0.stdout.take().expect("stdout")).read_line(&mut ready).expect("ready");
+        assert_eq!(ready.trim(), "ready");
+        process
+    }
+}
+
+impl Drop for HoldingProcess {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[test]
+fn pid_selects_its_transcript_over_newer_rollout_and_inherited_thread() {
+    let fixture = Fixture::new("selected");
+    let process = HoldingProcess::new(&fixture.selected, None);
+    let out = fixture.command(process.0.id()).output().expect("runs");
+    assert!(out.status.success());
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "SELECTED PANE");
+    assert!(out.stderr.is_empty(), "{}", String::from_utf8_lossy(&out.stderr));
+}
+
+#[test]
+fn duplicate_descriptors_do_not_make_one_transcript_ambiguous() {
+    let fixture = Fixture::new("duplicates");
+    let process = HoldingProcess::new(&fixture.selected, Some(&fixture.selected));
+    let out = fixture.command(process.0.id()).output().expect("runs");
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "SELECTED PANE");
+    assert!(out.stderr.is_empty(), "{}", String::from_utf8_lossy(&out.stderr));
+}
+
+#[test]
+fn ambiguous_pid_does_not_read_the_newest_session() {
+    let fixture = Fixture::new("ambiguous");
+    let process = HoldingProcess::new(&fixture.selected, Some(&fixture.other));
+    let out = fixture.command(process.0.id()).output().expect("runs");
+    assert!(out.status.success(), "--print reports discovery failures without aborting its caller");
+    assert!(out.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("2 open transcripts"));
+}
+
+#[test]
+fn pid_without_an_open_transcript_does_not_read_another_session() {
+    let fixture = Fixture::new("missing");
+    let process = HoldingProcess::new(Path::new("/dev/null"), None);
+    let out = fixture.command(process.0.id()).output().expect("runs");
+    assert!(out.status.success());
+    assert!(out.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("0 open transcripts"));
+}
+
+#[test]
+fn exact_session_id_still_precedes_pid_discovery() {
+    let fixture = Fixture::new("exact");
+    let process = HoldingProcess::new(&fixture.other, None);
+    let out = fixture.command(process.0.id()).args(["--session-id", SELECTED_ID]).output().expect("runs");
+    assert!(out.status.success());
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "SELECTED PANE");
+    assert!(out.stderr.is_empty(), "{}", String::from_utf8_lossy(&out.stderr));
+}

--- a/crates/plannotator-tui/tests/codex_pid.rs
+++ b/crates/plannotator-tui/tests/codex_pid.rs
@@ -9,6 +9,7 @@ use std::process::{Child, Command, Stdio};
 
 const SELECTED_ID: &str = "11111111-1111-4111-8111-111111111111";
 const OTHER_ID: &str = "22222222-2222-4222-8222-222222222222";
+const SUBAGENT_ID: &str = "33333333-3333-4333-8333-333333333333";
 
 #[derive(Debug)]
 struct Fixture {
@@ -28,16 +29,39 @@ impl Fixture {
     }
 
     fn rollout(directory: &Path, day: &str, id: &str, text: &str) -> PathBuf {
+        Self::write_rollout(directory, day, id, &[Self::assistant_message(id, text)])
+    }
+
+    /// A rollout Codex wrote for one of its subagents (a review, a guardian): the session
+    /// meta on the first line names `source.subagent`.
+    fn subagent_rollout(&self) -> PathBuf {
+        let meta = serde_json::json!({
+            "type": "session_meta",
+            "payload": {"id": SUBAGENT_ID, "source": {"subagent": "review"}}
+        });
+        let message = Self::assistant_message(SUBAGENT_ID, "SUBAGENT PANE");
+        Self::write_rollout(&self.directory, "03", SUBAGENT_ID, &[meta, message])
+    }
+
+    fn write_rollout(directory: &Path, day: &str, id: &str, lines: &[serde_json::Value]) -> PathBuf {
         let path =
             directory.join(format!("sessions/2026/09/{day}/rollout-2026-09-{day}T01-00-00-{id}.jsonl"));
         std::fs::create_dir_all(path.parent().expect("parent")).expect("session directory");
-        let message = serde_json::json!({
+        let mut text = String::new();
+        for line in lines {
+            text.push_str(&line.to_string());
+            text.push('\n');
+        }
+        std::fs::write(&path, text).expect("transcript");
+        path
+    }
+
+    fn assistant_message(id: &str, text: &str) -> serde_json::Value {
+        serde_json::json!({
             "type": "response_item",
             "payload": {"type": "message", "role": "assistant", "id": id,
                         "content": [{"type": "output_text", "text": text}]}
-        });
-        std::fs::write(&path, format!("{message}\n")).expect("transcript");
-        path
+        })
     }
 
     fn command(&self, pid: u32) -> Command {
@@ -101,6 +125,17 @@ fn duplicate_descriptors_do_not_make_one_transcript_ambiguous() {
     let fixture = Fixture::new("duplicates");
     let process = HoldingProcess::new(&fixture.selected, Some(&fixture.selected));
     let out = fixture.command(process.0.id()).output().expect("runs");
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "SELECTED PANE");
+    assert!(out.stderr.is_empty(), "{}", String::from_utf8_lossy(&out.stderr));
+}
+
+#[test]
+fn open_subagent_rollouts_do_not_make_one_transcript_ambiguous() {
+    let fixture = Fixture::new("subagent");
+    let subagent = fixture.subagent_rollout();
+    let process = HoldingProcess::new(&fixture.selected, Some(&subagent));
+    let out = fixture.command(process.0.id()).output().expect("runs");
+    assert!(out.status.success());
     assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "SELECTED PANE");
     assert!(out.stderr.is_empty(), "{}", String::from_utf8_lossy(&out.stderr));
 }


### PR DESCRIPTION
When Herdr supplies a Codex PID without an exact session, `last` ignores the PID and reads `CODEX_THREAD_ID` or the globally newest rollout. With several panes this can show another pane's reply.

On Linux, resolve the selected process's unique open rollout through `/proc/<pid>/fd` and pass that exact path to the existing reader. Duplicate descriptors for one file are deduplicated; missing or ambiguous transcripts report an error instead of falling through to another session. Explicit session paths/ids keep precedence, and the existing Herdr screen fallback remains available. Other platforms retain their current behavior.

Adds five CLI tests using real child processes holding fixture transcripts, plus a README note. Related: #57.

Fixes #60.

Validation on Linux (Rust 1.96.0):
- `cargo fmt --all --check`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked --workspace`
- `python3 herdr/test-manifest.py`
- `cargo build --locked --release -p plannotator-tui`
- Unix staging, byte comparison, and staged `--version`

Native Windows execution was not tested locally; the Linux-specific code and tests are conditionally compiled.
