### PR TITLE
release: 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,7 @@ checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plannotator-tui"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "plannotator-tui-hosts",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "plannotator-tui-hosts"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "rusqlite",
  "serde_json",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "plannotator-tui-schema"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "jsonschema",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/plannotator-tui-schema", "crates/plannotator-tui-hosts", "crates/plannotator-tui"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/crates/plannotator-tui/Cargo.toml
+++ b/crates/plannotator-tui/Cargo.toml
@@ -14,8 +14,8 @@ name = "plannotator-tui"
 path = "src/main.rs"
 
 [dependencies]
-plannotator-tui-schema = { path = "../plannotator-tui-schema", version = "0.6.0" }
-plannotator-tui-hosts = { path = "../plannotator-tui-hosts", version = "0.6.0" }
+plannotator-tui-schema = { path = "../plannotator-tui-schema", version = "0.7.0" }
+plannotator-tui-hosts = { path = "../plannotator-tui-hosts", version = "0.7.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Version bump for 0.7.0: workspace version, the two path-dependency versions in the binary crate, and the refreshed lockfile. Gate on this tree: fmt, clippy pedantic, 196 tests, release build reports 0.7.0.

Contents since v0.6.0: picker live preview (#54), picker times on the viewer's clock (#55), feedback archive (#56), Codex pid resolution on Linux (#61), Herdr Mirror split placement (#63), fallback visibility hint (#64), pre-release review fixes (#65), plus the dev-manifest staging commits (#51, #52).

Pre-release review: full plugin smoke suites passed on Herdr 0.8.2 and 0.9.0 with a TUI built from main; five findings, four fixed in #65 and one tracked as herdr-annotate#38 (Rust Lite parity, not in this release).