### PR TITLE
release: 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,7 @@ checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plannotator-tui"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "plannotator-tui-hosts",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "plannotator-tui-hosts"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "rusqlite",
  "serde_json",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "plannotator-tui-schema"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "jsonschema",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/plannotator-tui-schema", "crates/plannotator-tui-hosts", "crates/plannotator-tui"]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT"

--- a/crates/plannotator-tui/Cargo.toml
+++ b/crates/plannotator-tui/Cargo.toml
@@ -14,8 +14,8 @@ name = "plannotator-tui"
 path = "src/main.rs"
 
 [dependencies]
-plannotator-tui-schema = { path = "../plannotator-tui-schema", version = "0.7.0" }
-plannotator-tui-hosts = { path = "../plannotator-tui-hosts", version = "0.7.0" }
+plannotator-tui-schema = { path = "../plannotator-tui-schema", version = "0.8.0" }
+plannotator-tui-hosts = { path = "../plannotator-tui-hosts", version = "0.8.0" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Version bump for 0.8.0: workspace version, the two path-dependency versions in the binary crate, and the refreshed lockfile. Gate on this tree: fmt, clippy pedantic, 232 tests with the real feedback history verified untouched, release build reports 0.8.0.

Contents since v0.7.0: send only new annotations, the Review menu, finish review with archive and restore (#69, contributor feature reviewed and verified live inside Herdr), and the OSC 52 copy path pinned with tests (#68).